### PR TITLE
Add automerge configuration to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - 'Updating and Rebasing Branches': 'updating-rebasing.md'
       - 'Semantic Commit Messages': 'semantic-commits.md'
       - 'Noise Reduction': 'noise-reduction.md'
+      - 'Automerge configuration and troubleshooting': 'automerge-configuration.md'
   - Included Presets:
       - 'Full Config Presets': 'presets-config.md'
       - 'Default Presets': 'presets-default.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
       - 'Updating and Rebasing Branches': 'updating-rebasing.md'
       - 'Semantic Commit Messages': 'semantic-commits.md'
       - 'Noise Reduction': 'noise-reduction.md'
-      - 'Automerge configuration and troubleshooting': 'automerge-configuration.md'
+      - 'Automerging Updates': 'automerge-configuration.md'
   - Included Presets:
       - 'Full Config Presets': 'presets-config.md'
       - 'Default Presets': 'presets-default.md'


### PR DESCRIPTION
I'm not sure what's the best position in the sidebar for the automerge config docs.

Automerging is something that a lot of people want, so we could put it front and center in the `Getting Started:` sidebar.
Or we could say that automerging is something more advanced, and should go in `Deep Dives:`.

Fixes #30 