### PR TITLE
docs: add self-hosting link to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Getting Started:
       - 'GitHub App Installation': 'install-github-app.md'
       - 'GitLab App Installation': 'install-gitlab-app.md'
+      - 'Self-hosting': 'self-hosting.md'
       - 'Configure Renovate (Onboarding PR)': 'configure-renovate.md'
       - 'Private npm module support': 'private-modules.md'
       - 'Reconfiguring Renovate': 'reconfigure-renovate.md'


### PR DESCRIPTION
Currently we publish the doc page, but no link in sidebar to find it