### PR TITLE
ci: rename docs -> publish-docs and update badge

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,4 @@
-name: publish docs
+name: publish-docs
 
 on:
   push:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,4 @@
-name: docs
+name: publish docs
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![publish docs](https://github.com/renovatebot/renovatebot.github.io/workflows/publish%20docs/badge.svg?branch=build)
+![publish docs](https://github.com/renovatebot/renovatebot.github.io/workflows/publish-docs/badge.svg?branch=build)
 
 # docs.renovatebot.com
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![publish docs](https://github.com/renovatebot/renovatebot.github.io/workflows/publish-docs/badge.svg?branch=build)
+![publish-docs](https://github.com/renovatebot/renovatebot.github.io/workflows/publish-docs/badge.svg?branch=build)
 
 # docs.renovatebot.com
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build docs](https://github.com/renovatebot/renovatebot.github.io/workflows/docs/badge.svg?branch=build)
+![publish docs](https://github.com/renovatebot/renovatebot.github.io/workflows/publish%20docs/badge.svg?branch=build)
 
 # docs.renovatebot.com
 


### PR DESCRIPTION
## Changes:

- Rename `docs.yml` -> `publish-docs.yml`
- Rename name within action from `docs` -> `publish-docs`
- Update badge in README to use the new name

## Context:

The end goal of this GitHub Action is to publish the docs.
So I think it makes more sense to name the action: `publish-docs.yml` and use `publish-docs` as the action name.
I've also updated the badge to use the new name.