### PR TITLE
chore: create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+Please send an email to [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com) describing what you have found.
+Please do not raise an issue in this repository or publicize your concern in any other forum without giving us adequate time to investigate first.


### PR DESCRIPTION
## Changes:

- Create a `SECURITY.md` file that redirects security bugs to email

## Context:

We don't have this file here, but we already have one on the main Renovate repo.
So I copy/pasted this file from the Renovate main repo.