### PR TITLE
chore: only allow main Docusaurus v2 releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,10 @@
       "automergeType": "branch",
       "semanticCommitScope": "docs",
       "stabilityDays": 0
+    },
+    {
+      "packagePatterns": ["^@docusaurus"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-alpha\\.(\\d+))?$/"
     }
   ]
 }


### PR DESCRIPTION
## Changes:

- Only allow main Docusaurus v2 releases

## Context:

I'm using this in my own Docusaurus v2 repo to filter out the `canary` releases that Docusaurus releases on a regular basis.
Those `canary` releases are not meant for general use, so we should probably filter them out to reduce noise.

Source of regex: https://github.com/RoostingGeese/git-gosling/blob/main/renovate.json

---

Edit: @viceice You could also copy/paste this into your Docusaurus migration branch later, just wanted to let you know about this. 😄 