### PR TITLE
chore: create security section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ To build locally, run `make` and then `mkdocs serve`.
 ## Contributing
 
 If you would like to contribute to this repository or get a local copy running for some other reason, please see the instructions in [.github/contributing.md](.github/contributing.md).
+
+## Security / Disclosure
+
+If you discover any important bug with Renovate that may pose a security problem, please disclose it confidentially to renovate-disclosure@whitesourcesoftware.com first, so that it can be assessed and hopefully fixed prior to being exploited.
+Please do not raise GitHub issues for security-related doubts or problems.


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Copy/paste security section from Renovate bot main README

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

We have a SECURITY.md file, so that covers the Security tab on this repo, but we don't yet mention the security email in the README.md

This ensures we have the maximum chance to redirect security concerns to email.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
