### PR TITLE
chore: create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: You've found a bug on the documentation website
+---
+
+<!--
+      PLEASE DO NOT REPORT ANY SECURITY CONCERNS THIS WAY
+      Email renovate-disclosure@whitesourcesoftware.com instead.
+-->
+
+**What browser are you using?**
+
+<!-- Note: we do not support Internet Explorer 11. -->
+
+**Describe the bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**Steps to reproduce**
+
+<!--
+Explain how to reproduce the bug.
+Make screenshots if necessary.
+-->
+
+**Additional context**
+
+<!-- Add any other context about the problem here, including your own debugging or ideas on what went wrong. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Renovate bot config help
+    url: https://github.com/renovatebot/renovate/discussions
+    about: Please ask questions on how to configure your Renovate bot here.

--- a/.github/ISSUE_TEMPLATE/config_help_for_renovate_bot.md
+++ b/.github/ISSUE_TEMPLATE/config_help_for_renovate_bot.md
@@ -1,0 +1,13 @@
+---
+name: Configuration help for Renovate bot
+about: If you need help with the Renovate bot configuration
+---
+
+Stop!
+
+Configuration help questions for Renovate are very welcome!
+However, please don't create a new issue.
+Instead use the [discussions tab](https://github.com/renovatebot/renovate/discussions) on the `renovatebot/renovate` repository.
+
+Search the discussions forum to see if your config question is already answered.
+If not, create a new "config help" discussions post to get help from the Renovate team.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**What would you like to be able to do?**
+
+<!-- Tell us what requirements you need solving, and be sure to mention too if this is part of any "bigger" problem you're trying to solve. -->
+
+**Did you already have any implementation ideas?**
+
+<!-- In case you've already dug into existing options or source code and have ideas, mention them here. Try to keep implementation ideas separate from *requirements* above -->
+
+<!-- Please also mention here in case this is a feature you'd be interested in writing yourself, so you can be assigned it. -->


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Create issue templates for:
  - Bug reports
  - Feature requests
  - Redirect config help for Renovate bot to discussions on main Renovate bot repo
- Prevent users from opening empty issues by setting `blank_issues_enabled` to `false` in the `.github/ISSUE_TEMPLATE/config.yml` file
- Use the new `contact_links` option in the `config.yml` file to redirect users with config questions.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

Closes #43.

I found a really nice feature in the GitHub docs, turns out you can just flat-out ignore empty issue templates with a `config.yml` file. This prevents spammers from opening empty issues.

Quote from [GitHub docs, configuring the template chooser](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser):

> You can encourage contributors to use issue templates by setting `blank_issues_enabled `to `false`. If you set `blank_issues_enabled `to `true`, people will have the option to open a blank issue.

Another nice thing is that you can add a `contact_link`:

> If you prefer to receive certain reports outside of GitHub, you can direct people to external sites with `contact_links`.