### PR TITLE
docs: create local development docs

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -12,6 +12,7 @@ If you've found a **bug** or have a **feature request** then please create an is
 ## Code
 
 If you would like to fix a bug or implement a feature, please fork the repository and create a Pull Request.
+More information on getting set up locally can be found in [.github/local-development.md](https://github.com/renovatebot/renovatebot.github.io/blob/build/.github/local-development.md).
 
 Before you start any Pull Request, it's recommended that you create an issue to discuss first if you have any doubts about requirement or implementation.
 That way you can be sure that the maintainer(s) agree on what to change and how, and you can hopefully get a quick merge afterwards.

--- a/.github/local-development.md
+++ b/.github/local-development.md
@@ -12,7 +12,7 @@ You need the following dependencies for local development:
 
 - Git
 - Node.js `>=14.15.4`
-- Yarn `^1.17.0`
+- Yarn `^1.22.5`
 - Python `^3.9.1`
 - Bash shell with `make`
 

--- a/.github/local-development.md
+++ b/.github/local-development.md
@@ -13,7 +13,7 @@ You need the following dependencies for local development:
 - Git
 - Node.js `^12.13.0 || >=14.15.0`
 - Yarn `^1.17.0`
-- Python `^3.8`
+- Python `^3.9`
 - Bash shell with `make`
 
 We support Node.js versions according to the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule).

--- a/.github/local-development.md
+++ b/.github/local-development.md
@@ -11,9 +11,9 @@ For example, if you think anything is unclear, or you think something needs to b
 You need the following dependencies for local development:
 
 - Git
-- Node.js `^12.13.0 || >=14.15.0`
+- Node.js `>=14.15.4`
 - Yarn `^1.17.0`
-- Python `^3.9`
+- Python `^3.9.1`
 - Bash shell with `make`
 
 We support Node.js versions according to the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule).
@@ -23,7 +23,7 @@ _Linux_
 You can use the following commands on Ubuntu.
 
 ```sh
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update
@@ -32,28 +32,11 @@ sudo apt-get install -y git python-minimal build-essential nodejs yarn
 
 _Windows_
 
-QUESTION: Git Bash for Windows does not come with `make` by default, how should a user work around this? Or is Windows not supported for making the docs locally?
+Windows users should use Windows Subsystem for Linux version 2.
 
-Follow these steps to set up your development environment on Windows 10.
-If you already installed a component, skip the corresponding step.
+Read the [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/en-us/windows/wsl/) to learn more.
 
-- Install [Git](https://git-scm.com/downloads). Make sure you've [configured your username and email](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup)
-- Install [Node.js LTS](https://nodejs.org/en/download/)
-- In an Administrator PowerShell prompt, run `npm install -global npm` and then `npm --add-python-to-path='true' --debug install --global windows-build-tools`
-- Install [Yarn](https://yarnpkg.com/lang/en/docs/install/#windows-stable)
-
-  Verify you're using the appropriate versions:
-
-  ```powershell
-  PS C:\Windows\system32> git --version
-  git version 2.29.0.windows.1
-  PS C:\Windows\system32> node --version
-  v14.15.0
-  PS C:\Windows\system32> yarn --version
-  1.22.4
-  PS C:\Windows\system32> python --version
-  Python 3.8.1
-  ```
+Read the [VSCode documentation, Developing in WSL](https://code.visualstudio.com/docs/remote/wsl) to learn how to use WSL and VSCode.
 
 ## Fork and Clone
 

--- a/.github/local-development.md
+++ b/.github/local-development.md
@@ -1,0 +1,107 @@
+# Local Development
+
+This document gives tips and tricks on how to create the Renovate documentation website locally to add features or fix bugs.
+You can improve this documentation by opening a pull request.
+For example, if you think anything is unclear, or you think something needs to be added, open a pull request!
+
+## Installation
+
+### Prerequisites
+
+You need the following dependencies for local development:
+
+- Git
+- Node.js `^12.13.0 || >=14.15.0`
+- Yarn `^1.17.0`
+- Python `^3.8`
+- Bash shell with `make`
+
+We support Node.js versions according to the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule).
+
+_Linux_
+
+You can use the following commands on Ubuntu.
+
+```sh
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt-get update
+sudo apt-get install -y git python-minimal build-essential nodejs yarn
+```
+
+_Windows_
+
+QUESTION: Git Bash for Windows does not come with `make` by default, how should a user work around this? Or is Windows not supported for making the docs locally?
+
+Follow these steps to set up your development environment on Windows 10.
+If you already installed a component, skip the corresponding step.
+
+- Install [Git](https://git-scm.com/downloads). Make sure you've [configured your username and email](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup)
+- Install [Node.js LTS](https://nodejs.org/en/download/)
+- In an Administrator PowerShell prompt, run `npm install -global npm` and then `npm --add-python-to-path='true' --debug install --global windows-build-tools`
+- Install [Yarn](https://yarnpkg.com/lang/en/docs/install/#windows-stable)
+
+  Verify you're using the appropriate versions:
+
+  ```powershell
+  PS C:\Windows\system32> git --version
+  git version 2.29.0.windows.1
+  PS C:\Windows\system32> node --version
+  v14.15.0
+  PS C:\Windows\system32> yarn --version
+  1.22.4
+  PS C:\Windows\system32> python --version
+  Python 3.8.1
+  ```
+
+## Fork and Clone
+
+If you want to contribute to the project, you should first "fork" the main project using the GitHub Website and then clone your fork locally.
+The Renovate project uses the [Yarn](https://github.com/yarnpkg/yarn) package management system instead of npm.
+
+To ensure everything is working properly on your end, you must:
+
+1. Make sure you don't have a local `.npmrc` file that overrides npm's default registry
+1. Install all npm dependencies with `yarn install`
+1. Install all Python dependencies with `pip install -r requirements.txt`
+1. Make a build with `make`
+1. Serve the build of the website locally with `mkdocs serve`
+
+You only need to do these 5 steps this one time.
+
+Before you submit a pull request you should:
+
+1. Install newer npm dependencies with `yarn install`
+1. Install newer Python dependencies with `pip install -r requirements.txt`
+1. Make a build with `make`
+1. Serve your build locally with `mkdocs serve` and inspect if everything is working
+
+## Tests
+
+### Prerequisites
+
+<!-- TODO: Once we have Jest working with Docusaurus, explain how to set it up. -->
+
+### Jest
+
+<!-- TODO: setup snapshot tests with Jest on React components. -->
+
+### Coverage
+
+<!-- TODO: fill in once we have tests and a coverage bot -->
+
+## Linting and formatting
+
+<!--- TODO: Once Prettier is setup, explain how to use it. -->
+
+## Keeping your Renovate fork up to date
+
+First of all, never commit to `build` of your fork - always use a branch like `style/fix-css-error`.
+
+Then, make sure your fork is up to date with `build` each time before creating a new branch.
+To do this, see these GitHub guides:
+
+[Configuring a remote for a fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/)
+
+[Syncing a fork](https://help.github.com/articles/syncing-a-fork/)

--- a/.github/local-development.md
+++ b/.github/local-development.md
@@ -18,26 +18,6 @@ You need the following dependencies for local development:
 
 We support Node.js versions according to the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule).
 
-_Linux_
-
-You can use the following commands on Ubuntu.
-
-```sh
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt-get update
-sudo apt-get install -y git python-minimal build-essential nodejs yarn
-```
-
-_Windows_
-
-Windows users should use Windows Subsystem for Linux version 2.
-
-Read the [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/en-us/windows/wsl/) to learn more about WSL.
-
-Read the [VSCode documentation, Developing in WSL](https://code.visualstudio.com/docs/remote/wsl) to learn how to use WSL and VS Code.
-
 ## Fork and Clone
 
 If you want to contribute to the project, you should first "fork" the main project using the GitHub website and then clone your fork locally.
@@ -46,45 +26,19 @@ The Renovate project uses the [Yarn](https://github.com/yarnpkg/yarn) package ma
 To ensure everything is working properly on your end, you must:
 
 1. Make sure you don't have a local `.npmrc` file that overrides npm's default registry
-1. Install all npm dependencies with `yarn install`
-1. Install all Python dependencies with `pip install -r requirements.txt`
-1. Make a build with `make`
+1. Run `make` to install all dependencies and make a build
 1. Serve the build of the website locally with `mkdocs serve`
-
-You only need to do these 5 steps this one time.
 
 Before you submit a pull request you should:
 
-1. Install newer npm dependencies with `yarn install`
-1. Install newer Python dependencies with `pip install -r requirements.txt`
-1. Make a build with `make`
-1. Serve your build locally with `mkdocs serve` and inspect if everything is working
-
-## Tests
-
-### Prerequisites
-
-<!-- TODO: Once we have Jest working with Docusaurus, explain how to set it up. -->
-
-### Jest
-
-<!-- TODO: setup snapshot tests with Jest on React components. -->
-
-### Coverage
-
-<!-- TODO: fill in once we have tests and a coverage bot -->
-
-## Linting and formatting
-
-<!--- TODO: Once Prettier is setup, explain how to use it. -->
+1. Ensure your feature branch is up-to-date with the upstream `build` branch
+1. Run `make` to install all dependencies and make a build
+1. Serve the build of the website locally with `mkdocs serve`
 
 ## Keeping your Renovate fork up to date
 
 First of all, never commit to `build` of your fork - always use a branch like `style/fix-css-error`.
 
-Then, make sure your fork is up to date with `build` each time before creating a new branch.
-To do this, see these GitHub guides:
+Make sure your fork's `build` branch is up to date with the upstream `build` before creating a new branch, read the [GitHub docs, syncing a fork](https://help.github.com/articles/syncing-a-fork/).
 
-[Configuring a remote for a fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/)
-
-[Syncing a fork](https://help.github.com/articles/syncing-a-fork/)
+If you're working with Git locally, you need to configure the remote branch correctly, read the[GitHub docs, configuring a remote for a fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/) to learn how to do this.

--- a/.github/local-development.md
+++ b/.github/local-development.md
@@ -34,13 +34,13 @@ _Windows_
 
 Windows users should use Windows Subsystem for Linux version 2.
 
-Read the [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/en-us/windows/wsl/) to learn more.
+Read the [Windows Subsystem for Linux Documentation](https://docs.microsoft.com/en-us/windows/wsl/) to learn more about WSL.
 
-Read the [VSCode documentation, Developing in WSL](https://code.visualstudio.com/docs/remote/wsl) to learn how to use WSL and VSCode.
+Read the [VSCode documentation, Developing in WSL](https://code.visualstudio.com/docs/remote/wsl) to learn how to use WSL and VS Code.
 
 ## Fork and Clone
 
-If you want to contribute to the project, you should first "fork" the main project using the GitHub Website and then clone your fork locally.
+If you want to contribute to the project, you should first "fork" the main project using the GitHub website and then clone your fork locally.
 The Renovate project uses the [Yarn](https://github.com/yarnpkg/yarn) package management system instead of npm.
 
 To ensure everything is working properly on your end, you must:


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Create local development docs based off [renovatebot/renovate/docs/development/local-development.md](https://github.com/renovatebot/renovate/blob/master/docs/development/local-development.md)
- Adjust docs where needed so that they have the correct instructions

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

We have nothing that accurately describes the current steps to re-create the documentation website locally.
I know we're going to migrate to Docusaurus v2 sometime, but we should have at least a template that we can fill in properly later.