### PR TITLE
docs: move FAQ to stand-alone entry on sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
       - 'Configure Renovate (Onboarding PR)': 'configure-renovate.md'
       - 'Private npm module support': 'private-modules.md'
       - 'Reconfiguring Renovate': 'reconfigure-renovate.md'
-  - Frequently Asked Questions (FAQ): 'faq.md'
+  - Frequently Asked Questions: 'faq.md'
   - Configuration Options: 'configuration-options.md'
   - Self Hosted Configuration: 'self-hosted-configuration.md'
   - Renovate Modules:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - 'Configure Renovate (Onboarding PR)': 'configure-renovate.md'
       - 'Private npm module support': 'private-modules.md'
       - 'Reconfiguring Renovate': 'reconfigure-renovate.md'
+  - Frequently Asked Questions (FAQ): 'faq.md'
   - Configuration Options: 'configuration-options.md'
   - Self Hosted Configuration: 'self-hosted-configuration.md'
   - Renovate Modules:
@@ -71,4 +72,3 @@ nav:
   - All Other:
       - 'Merge Confidence': 'merge-confidence.md'
       - 'Templates': 'templates.md'
-      - 'Frequently Asked Questions (FAQ)': 'faq.md'


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Move FAQ so that is has its own entry in the sidebar

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

The current location of the FAQ makes it unlikely that new Renovate users actually find it.

EDIT: we have decided to put the FAQ in the sidebar by itself.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
