### PR TITLE
feat: generate yaml code blocks from json config examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+__pycache__
+/.venv
 /docs
 /node_modules
 /site

--- a/bin/hooks.py
+++ b/bin/hooks.py
@@ -1,0 +1,48 @@
+import json
+import logging
+import re
+from textwrap import indent
+
+import yaml
+
+
+log = logging.getLogger("mkdocs.mkdocs_simple_hooks")
+
+CODEBLOCK_INDENT = " " * 4
+CODEBLOCK_JSON_RE = re.compile(r"```json\s*(.*?)```", re.DOTALL)
+CODEBLOCK_TABBED = """\
+=== "json"
+
+    ``` json
+
+%s
+
+    ```
+
+=== "YAML"
+
+    ``` yaml
+    
+%s
+
+    ```\
+"""
+
+
+def _substitute_codeblocks(block):
+    match = block.group(1)
+    try:
+        parsed = json.loads(match)
+    except json.decoder.JSONDecodeError as e:
+        log.warn(f"Invalid JSON: {e}\nSkipping YAML block creation")
+        return match
+
+    json_block = indent(match.strip(), CODEBLOCK_INDENT)
+    yaml_block = indent(yaml.dump(parsed), CODEBLOCK_INDENT)
+
+    return CODEBLOCK_TABBED % (json_block, yaml_block)
+
+
+def make_tabbed_codeblocks(markdown, page, config, **kwargs):
+    log.info(f"Adding YAML codeblocks to {page.file.src_path}")
+    return re.sub(CODEBLOCK_JSON_RE, _substitute_codeblocks, markdown)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,14 @@ extra_javascript:
 # Extensions
 markdown_extensions:
   - meta
+  - pymdownx.superfences
+  - pymdownx.tabbed
+
+plugins:
+  - search
+  - mkdocs-simple-hooks:
+      hooks:
+        on_page_markdown: "bin.hooks:make_tabbed_codeblocks"
 
 # Page Tree
 nav:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-markdown==3.2
-mkdocs==1.0.4
-mkdocs-material==4.6.3
+markdown==3.2.1
+mkdocs==1.2.1
+mkdocs-material==7.1.9
+mkdocs-simple-hooks==0.1.3
+pyyaml==5.4.1


### PR DESCRIPTION
## Changes:

Adds a simple postprocessor to create a tabbed json/yaml codeblock if the code in existing example blocks is valid JSON, log a warning otherwise.

The logging, yaml indent/flow and other things can still be tweaked of course, just a demo for https://github.com/renovatebot/renovate/issues/7031.

I did have to bump the mkdocs stack to make sure the configuration was picked up correctly, so this may need a manual check that everything is OK, but seems fine to me so far.

## Context:

For discussion in https://github.com/renovatebot/renovate/issues/7031. Depends on that feature first of course.