### PR TITLE
chore: pin versions when installing deps locally

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-save-prefix ""


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Tell Yarn to use pinned versions (exact versions) when installing (dev) dependencies

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

We have setup our Renovate bot to use pinned dependencies, but when you use Yarn locally, you can still accidentally install packages using a range.

This PR makes it so that Yarn will always install using a exact version.