### PR TITLE
docs: add Renovate Scheduling under Key Concepts category

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - 'Presets': 'config-presets.md'
   - Key Concepts:
       - 'Dependency Dashboard': 'key-concepts/dashboard.md'
+      - 'Renovate Scheduling': 'key-concepts/scheduling.md'
   - Renovate Modules:
       - 'Platforms': 'modules/platform.md'
       - 'Managers': 'modules/manager.md'


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add Renovate Scheduling under Key Concepts category 

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I hope this is correct to add the new page "renovate scheduling" from https://github.com/renovatebot/renovate/pull/11278 to the sidebar.

Please check my work! 😉 

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
