### PR TITLE
docs: rename file, move automerge to key-concepts

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Key Concepts:
       - 'Dependency Dashboard': 'key-concepts/dashboard.md'
       - 'Renovate Scheduling': 'key-concepts/scheduling.md'
+      - 'Automerge': 'key-concepts/automerge.md'
   - Renovate Modules:
       - 'Platforms': 'modules/platform.md'
       - 'Managers': 'modules/manager.md'
@@ -59,7 +60,6 @@ nav:
       - 'Updating and Rebasing Branches': 'updating-rebasing.md'
       - 'Semantic Commit Messages': 'semantic-commits.md'
       - 'Noise Reduction': 'noise-reduction.md'
-      - 'Automerging Updates': 'automerge-configuration.md'
   - Included Presets:
       - 'Full Config Presets': 'presets-config.md'
       - 'Default Presets': 'presets-default.md'


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- File was renamed upstream from `docs/usage/automerge-configuration.md` to `docs/usage/key-concepts/automerge.md`
- Move file to new key-concepts category in the sidebar

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

Upstream PR to track:

- https://github.com/renovatebot/renovate/pull/11490

Only merge this PR once you see the new section `automerge` in https://github.com/renovatebot/renovatebot.github.io/tree/main/key-concepts