### PR TITLE
Revert "chore: only allow main Docusaurus v2 releases"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,6 @@
       "automergeType": "branch",
       "semanticCommitScope": "docs",
       "stabilityDays": 0
-    },
-    {
-      "packagePatterns": ["^@docusaurus"],
-      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-alpha\\.(\\d+))?$/"
     }
   ]
 }


### PR DESCRIPTION
Reverts renovatebot/renovatebot.github.io#51