### PR TITLE
docs: add troubleshooting file to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,9 @@ nav:
       - 'Use Cases': 'getting-started/use-cases.md'
       - 'Running Renovate': 'getting-started/running.md'
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
-      - 'Troubleshooting': 'getting-started/troubleshooting.md'
       - 'Private Packages': 'getting-started/private-packages.md'
+  - Troubleshooting:
+      - 'Troubleshooting': 'troubleshooting.md'
   - Configuration:
       - 'Self-hosted': 'self-hosted-configuration.md'
       - 'Repository': 'configuration-options.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,8 +30,7 @@ nav:
       - 'Running Renovate': 'getting-started/running.md'
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
       - 'Private Packages': 'getting-started/private-packages.md'
-  - Troubleshooting:
-      - 'Troubleshooting': 'troubleshooting.md'
+  - Troubleshooting: 'troubleshooting.md'
   - Configuration:
       - 'Self-hosted': 'self-hosted-configuration.md'
       - 'Repository': 'configuration-options.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - 'Use Cases': 'getting-started/use-cases.md'
       - 'Running Renovate': 'getting-started/running.md'
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
+      - 'Troubleshooting Renovate': 'getting-started/troubleshooting.md'
       - 'Private Packages': 'getting-started/private-packages.md'
   - Configuration:
       - 'Self-hosted': 'self-hosted-configuration.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
       - 'Use Cases': 'getting-started/use-cases.md'
       - 'Running Renovate': 'getting-started/running.md'
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
-      - 'Troubleshooting Renovate': 'getting-started/troubleshooting.md'
+      - 'Troubleshooting': 'getting-started/troubleshooting.md'
       - 'Private Packages': 'getting-started/private-packages.md'
   - Configuration:
       - 'Self-hosted': 'self-hosted-configuration.md'


### PR DESCRIPTION
## Changes:

- Add new page "Troubleshooting Renovate` to the sidebar

## Context:

We can merge this once we see that the `troubleshooting` folder exists in https://github.com/renovatebot/renovatebot.github.io/tree/main

Upstream PR that adds the documentation page: https://github.com/renovatebot/renovate/pull/11897
Upstream PR that moves the file to a better location: https://github.com/renovatebot/renovate/pull/11937