### PR TITLE
docs: add Known Limitations to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,6 @@ nav:
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
       - 'Private Packages': 'getting-started/private-packages.md'
   - Troubleshooting: 'troubleshooting.md'
-  - Known Limitations: 'known-limitations.md'
   - Configuration:
       - 'Self-hosted': 'self-hosted-configuration.md'
       - 'Repository': 'configuration-options.md'
@@ -76,3 +75,4 @@ nav:
       - 'Merge Confidence': 'merge-confidence.md'
       - 'Templates': 'templates.md'
       - 'Frequently Asked Questions': 'faq.md'
+      - 'Known Limitations': 'known-limitations.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
       - 'Private Packages': 'getting-started/private-packages.md'
   - Troubleshooting: 'troubleshooting.md'
+  - Known Limitations: 'known-limitations.md'
   - Configuration:
       - 'Self-hosted': 'self-hosted-configuration.md'
       - 'Repository': 'configuration-options.md'


### PR DESCRIPTION
## Changes:

- Add upstream new page covering Known Limitations to the sidebar

## Context:

This upstream PR should be merged first: https://github.com/renovatebot/renovate/pull/11946

We can merge this PR once we see the new folder Known Limitations here: https://github.com/renovatebot/renovatebot.github.io/tree/main