### PR TITLE
docs: add missing presets to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,10 @@ nav:
       - 'Package Presets': 'presets-packages.md'
       - 'Preview Presets': 'presets-preview.md'
       - 'Schedule Presets': 'presets-schedule.md'
+      - 'Workaround Presets': 'presets-workarounds.md'
+      - 'Compatibility Presets': 'presets-compatibility.md'
+      - 'npm Presets': 'presets-npm.md'
+      - 'Regex Manager Presets': 'presets-regexManagers.md'
   - All Other:
       - 'Merge Confidence': 'merge-confidence.md'
       - 'Templates': 'templates.md'


### PR DESCRIPTION
## Changes:

Add the following preset pages to the sidebar:

- 'Workaround Presets'
- 'Compatibility Presets'
- 'npm Presets'
- 'Regex Manager Presets'

## Context:

Now all preset pages have a entry in the sidebar. 😉 