### PR TITLE
chore(deps): update dessant/lock-threads action to v3

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,13 +8,21 @@ on:
   # allow manual trigger
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
+# Ensure only one lock action can run at a time
+concurrency:
+  group: lock
+
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@f1a42f0f44eb83361d617a014663e1a76cf282d2 # renovate: tag=v2.1.2
+      - uses: dessant/lock-threads@e460dfeb36e731f3aeb214be6b0c9a9d9a67eda6 # renovate: tag=v3.0.0
         if: github.repository == 'renovatebot/renovatebot.github.io'
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: 30
-          pr-lock-inactive-days: 30
+          issue-inactive-days: 30
+          pr-inactive-days: 30


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Update `dessant/lock-threads` to `v3`
- Migrate input names to newer terms
- Specify permissions
- Limit concurrency

## Context:

Basically a copy/paste of the file we have over on the main renovate repository: https://github.com/renovatebot/renovate/blob/main/.github/workflows/lock.yml with one small adjustment to keep `if: github.repository == 'renovatebot/renovatebot.github.io'` from the file we have now.
