### PR TITLE
docs: add self-hosting examples to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Getting Started:
       - 'Use Cases': 'getting-started/use-cases.md'
       - 'Running Renovate': 'getting-started/running.md'
+      - 'Self-Hosting Examples': 'examples/self-hosting.md'
       - 'Installing & Onboarding': 'getting-started/installing-onboarding.md'
       - 'Private Packages': 'getting-started/private-packages.md'
   - Troubleshooting: 'troubleshooting.md'


### PR DESCRIPTION
## Changes:

- Add Self-Hosting Examples page to sidebar

## Context:

You could only find this page by using the docs search feature.
It makes sense to have this page on the sidebar as well for increased visibility.

Helps with Renovate issue: https://github.com/renovatebot/renovate/issues/7595

Verified that this works by running `mkdocs serve` in Gitpod and checking the preview in the browser.