### PR TITLE
chore: enable syntax highlighting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ extra_javascript:
 # Extensions
 markdown_extensions:
   - meta
+  - pymdownx.highlight
+  - pymdownx.superfences
 
 # Page Tree
 nav:


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Enable syntax highlighting

## Context:

We can use syntax highlighting for any Markdown code blocks that have the language mentioned after the three backticks, like this:

```json
{
  "extends": ["config:base", ":disableDependencyDashboard"]
}
```

The documentation for this option can be found here: [Material for MkDocs, Python Markdown Extensions, Highlight](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#highlight).

I think it looks better this way! Let me know what you think. 😉

Not closing any existing issue with this.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/build/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
