### PR TITLE
Revert "chore: enable syntax highlighting (#97)"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,8 +55,6 @@ extra_javascript:
 # Extensions
 markdown_extensions:
   - meta
-  - pymdownx.highlight
-  - pymdownx.superfences
 
 # Page Tree
 nav:


### PR DESCRIPTION
Reverts renovatebot/renovatebot.github.io#97

I think we should revert this change and figure out what's causing the bad behavior as described in bug report #99. Once we fix bug #99 we can re-enable syntax highlighting again.

It's a shame this breaks the display here, because I do like it when it works properly. 😞