### PR TITLE
docs(index): update outside contributors number

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -22,7 +22,7 @@ Renovate's automation capabilities mean that projects which previously fell behi
 ## Renovate development and use
 
 Renovate source is available ([renovatebot/renovate](https://github.com/renovatebot/renovate) on GitHub), where most of the development is done.
-Renovate was created by [WhiteSource](https://www.whitesourcesoftware.com/) staff and they continue to push Renovate forward, but is also made possible through more than 400 outside contributors.
+Renovate was created by [WhiteSource](https://www.whitesourcesoftware.com/) staff and they continue to push Renovate forward, but is also made possible through more than 500 outside contributors.
 
 Renovate is distributed as [an Open Source npm package](https://www.npmjs.com/package/renovate), as [pre-built Open Source images on Docker Hub](https://hub.docker.com/repository/docker/renovate/renovate), or as a [free GitHub App](https://github.com/marketplace/renovate) hosted by WhiteSource.
 


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Update outside contributors number

## Context:

Steps to reproduce:

1. Run `git shortlog --numbered --summary > summary-contributors.md` on the latest `main` branch of the `renovatebot/renovate` repository.
1. Open the generated file in the IDE,  scroll down to bottom of file to see the linenumber.
1. Right now the linenumber is `516`. 🥳 

Easier method: go to the https://github.com/renovatebot/renovate homepage and look at the sidebar:

![contributors-sidebar-renovate-repo](https://user-images.githubusercontent.com/34918129/146154418-64362d41-0d18-4bdc-89e8-c3dece513c70.png)
