### PR TITLE
chore: get PRs for minor python, don't automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,8 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor"],
+      "automerge": false,
       "matchManagers": ["pip_requirements"],
-      "dependencyDashboardApproval": true
     },
     {
       "matchManagers": ["git-submodules"],


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Improve our Renovate configuration so that we get `minor` python package update PRs automatically
- Remove the requirement to request minor python package updates from the Dependency Dashboard

## Context:

Closes #121.