### PR TITLE
chore: enable instant loading

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ theme:
 
   features:
     - navigation.top # Add back to top button
+    - navigation.instant
 
 # Setup button to edit page on GitHub.
 # Works correctly for most pages, but will be wrong in some cases.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,8 +36,8 @@ theme:
 
   features:
     - navigation.top # Add back to top button
-    - navigation.instant # Use instant loading for internal links
     - toc.integrate # Integrate table of contents into left sidebar
+    - navigation.instant # Use instant loading for internal links
 
 # Setup button to edit page on GitHub.
 # Works correctly for most pages, but will be wrong in some cases.


### PR DESCRIPTION
## Changes:

- Enable instant loading

## Context:

This is the killer feature of Material for MkDocs and we're not using it, quote from the docs (I've **bolded** the relevant part):

> Material for MkDocs provides a multitude of options to configure the behavior of navigational elements, including tabs and sections, **and its flag-ship feature: instant loading.**

I'll let the docs explain: [^docs]

> When instant loading is enabled, clicks on all internal links will be intercepted and dispatched via XHR without fully reloading the page.
>
> The resulting page is parsed and injected and all event handlers and components are rebound automatically, i.e., Material for MkDocs now behaves like a Single Page Application.
> Now, the search index survives navigation, which is especially useful for large documentation sites.

## Test procedure

I've tested this change with Gitpod, by making the change in this PR, and then running `mkdocs serve` to get the page preview. I then clicked on the links in the sidebar (these all are "internal" links), and had the page preview and the production page side by side.

Loading the pages in the preview is faster, and the viewport does not "flash" with a reload anymore. It feels a lot snappier now to navigate the internal links.

I don't know how I can quantify this "speedup" in actual numbers.

[^docs]: https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=integrate#instant-loading