### PR TITLE
chore: integrate table of contents

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ theme:
 
   features:
     - navigation.top # Add back to top button
+    - toc.integrate
 
 # Setup button to edit page on GitHub.
 # Works correctly for most pages, but will be wrong in some cases.


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Integrate the table of contents into the sidebar on the left

## Context:

Quote from the docs: [^docs]

> When navigation integration for the table of contents is enabled, it is always rendered as part of the navigation sidebar on the left.

**Pros:**

- It's more intuitive to have a summary of the content in the sidebar on the left
- All content can now be searched in one place, instead of spread out over two sidebars.
- The new layout has more space for the actual content, right now the content is "squished" between two sidebars

**Cons:**

- It's different than what we had before
- It can be a bit of a scroll to reach the end of the sidebar on the left, for example if you're on the Repository Config options page

**Same:**

- There is a problem with longer text not being displayed fully in the sidebar, but we already have the same problem with the sidebar on the right... Check out the sidebar entry for this link: https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose

[^docs]: https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=integrate#integrated-table-of-contents
