### PR TITLE
chore: add permalink behind headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,11 @@ markdown_extensions:
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=meta#metadata
   - meta
 
+  # The toc.permalink extension adds a permalink behind each heading.
+  # https://python-markdown.github.io/extensions/toc/#usage
+  - toc:
+      permalink: true
+
   # The Highlight extension adds support for syntax highlighting of code blocks (with the help of SuperFences)
   # and inline code blocks (with the help of InlineHilite).
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/?h=highlig#highlight


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add permalink behind headings

## Context:

When you hover/tab behind the heading name, you'll see a "paragraph" icon that contains a permanent link to that heading.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
