### PR TITLE
chore: add custom `edit_uri` code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tmp
 /renovate-schema.json
 /dist
+__pycache__

--- a/hooks.py
+++ b/hooks.py
@@ -7,3 +7,7 @@ def on_page_markdown(markdown, page, **kwargs):
     edit_url = page.meta.get('edit_url')
     if edit_url:
         page.edit_url = edit_url
+
+    repo_url = page.meta.get('repo_url')
+    if repo_url:
+        page.repo_url= repo_url

--- a/hooks.py
+++ b/hooks.py
@@ -1,0 +1,9 @@
+# This code is in the public domain.
+# Based on work from Oleh Prypin.
+# Link to their GitHub account: https://github.com/oprypin
+# Offered code as public domain: https://github.com/mkdocs/mkdocs/discussions/2757#discussioncomment-2092565
+
+def on_page_markdown(markdown, page, **kwargs):
+    edit_url = page.meta.get('edit_url')
+    if edit_url:
+        page.edit_url = edit_url

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,13 @@ strict: true
 # https://www.mkdocs.org/user-guide/configuration/#remote_branch
 remote_branch: gh-pages
 
+# Plugins
+
+plugins:
+  - mkdocs-simple-hooks:
+      hooks:
+        on_page_markdown: 'hooks:on_page_markdown'
+
 # General site info
 
 # Metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 markdown==3.3.6
 mkdocs==1.2.3
 mkdocs-material==8.2.1
+mkdocs-simple-hooks==0.1.5

--- a/src/index.md
+++ b/src/index.md
@@ -1,3 +1,8 @@
+---
+edit_uri: edit/main/src/index.md
+repo_url: https://github.com/renovatebot/renovatebot.github.io
+---
+
 ![Renovate banner](https://app.renovatebot.com/images/whitesource_renovate_660_220.jpg)
 
 # Renovate documentation


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Create custom `edit_uri` code

## Context:

This PR should make it so that:

- We can override the "edit this page"/pencil button URL for files that are not under the main Renovatebot repository `docs/usage` folder
- Override the URL to the source repository (for `index.md` and `about-us.md` that are hosted in the `renovatebot.github.io` repo)

## License + credit

The parts from @oprypin are offered under public domain. 
I've credited them in the `hooks.py` file and in the first git commit message.

## Code not functional yet

I can't get this working on my end. I'm marking this PR as a draft for now. Help wanted. 😉 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
