### PR TITLE
docs: rewrite security sections

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,9 +1,12 @@
 # Contributing
 
-## Security
+## Security / Disclosure
 
-If you think you've found a **security issue**, please do not mention it in this repository.
-Instead, email renovate-disclosure@whitesourcesoftware.com with as much details as possible so that it can be handled confidentially.
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
+
+Please do not create GitHub issues for security-related doubts or problems.
 
 ## Bug Reports and Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -16,5 +16,8 @@ If you would like to contribute to this repository or get a local copy running f
 
 ## Security / Disclosure
 
-If you discover any important bug with Renovate that may pose a security problem, please disclose it confidentially to renovate-disclosure@whitesourcesoftware.com first, so that it can be assessed and hopefully fixed prior to being exploited.
-Please do not raise GitHub issues for security-related doubts or problems.
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
+
+Please do not create GitHub issues for security-related doubts or problems.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,7 @@
-# Security Policy
+# Security / Disclosure
 
-Please send an email to [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com) describing what you have found.
-Please do not raise an issue in this repository or publicize your concern in any other forum without giving us adequate time to investigate first.
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
+
+Please do not create GitHub issues for security-related doubts or problems.


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Rewrite security sections

## Context:

Follow-up PR after https://github.com/renovatebot/renovate/pull/14773

Copy and paste of the security section from our main Renovate readme. 

Now our security sections are the same in the main Renovate repository and our docs publishing repository.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
