### PR TITLE
docs: publish security.txt

### DIFF
--- a/src/security.txt
+++ b/src/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:renovate-disclosure@whitesourcesoftware.com
+Expires: 2022-12-31T22:59:00.000Z
+Preferred-Languages: en

--- a/src/security.txt
+++ b/src/security.txt
@@ -1,3 +1,3 @@
 Contact: mailto:renovate-disclosure@whitesourcesoftware.com
-Expires: 2022-12-31T22:59:00.000Z
+Expires: 2022-12-31T23:59:00.000Z
 Preferred-Languages: en


### PR DESCRIPTION
## Changes:

- Create `security.txt` in `src` directory

## Context:

Fixes #152. I'm following the specs from https://securitytxt.org/.

> **Where should I put the security.txt file?**
> 
> For websites, the security.txt file should be placed under the `/.well-known/` path. It can also be placed in the root directory (`/security.txt`) of a website, especially if the `/.well-known/` directory cannot be used for technical reasons, or simply as a fallback. The file can be placed in both locations of a website at the same time.

I cannot get `.well-known/security.txt` to work. So I'm falling back to `src/security.txt`. 🙈 

The content of the `src/` directory gets copied by this script:

https://github.com/renovatebot/renovatebot.github.io/blob/2bccdd6770bc55b1325c4ee3985a7995de489d80/bin/get-docs.sh#L1-L26