### PR TITLE
chore: change light/dark mode toggle icon order

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,14 +49,14 @@ theme:
     - media: '(prefers-color-scheme: light)'
       scheme: default
       toggle:
-        icon: material/weather-sunny
+        icon: material/weather-night
         name: Switch to dark mode
       primary: 'blue'
       accent: 'blue'
     - media: '(prefers-color-scheme: dark)'
       scheme: slate
       toggle:
-        icon: material/weather-night
+        icon: material/weather-sunny
         name: Switch to light mode
       primary: 'cyan'
       accent: 'cyan'


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Swaps the icons for the light and dark mode

## Context:

**Currently:**

1. Start on Light mode, click on Sun icon to go to Dark mode
2. From Dark mode, click on Moon icon to go to light mode
3. Hover text doesn't match icon

**In this PR:**

1. Start on Light mode, click on Moon to go to dark mode
2. From Dark mode, click on Sun to go to light mode
3. Hover text matches icon

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
