### PR TITLE
docs: add presets key concepts page to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - 'Repository': 'configuration-options.md'
       - 'Presets': 'config-presets.md'
   - Key Concepts:
+      - 'Presets': 'key-concepts/presets.md'
       - 'Dependency Dashboard': 'key-concepts/dashboard.md'
       - 'Renovate Scheduling': 'key-concepts/scheduling.md'
       - 'Automerge': 'key-concepts/automerge.md'


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add key concepts page for presets to the sidebar/nav

## Context:

I forgot to add the new key concepts presets page to our sidebar after merging PR https://github.com/renovatebot/renovate/pull/15396. So I'm fixing the sidebar with this PR now. 😄 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
