### PR TITLE
docs: credit maintainers and contributors

### DIFF
--- a/src/about-us.md
+++ b/src/about-us.md
@@ -30,7 +30,7 @@ Next up, we have these people who help maintain parts of Renovate:
 ### Valuable contributions
 
 We want to highlight these valuable contributions, even if they are one-offs.
-Some feature made a lot of people happy, and efficient!
+Some features made a lot of people happy, and efficient!
 
 - [@ikesyo](https://github.com/ikesyo) regularly helpful
 - [@astellingwerf](https://github.com/astellingwerf) reviews PRs

--- a/src/about-us.md
+++ b/src/about-us.md
@@ -6,8 +6,8 @@ More than 600 outside contributors helped improve Renovate.
 
 ## Special thanks
 
-We want to highlight the work of some very awesome people.
-Thank you very much for your time and effort!
+We want to highlight the work of these awesome people.
+Thank you for your time and effort!
 
 ### Maintainers
 

--- a/src/about-us.md
+++ b/src/about-us.md
@@ -34,7 +34,7 @@ Some features made a lot of people happy, and efficient!
 
 - [@ikesyo](https://github.com/ikesyo) regularly helpful
 - [@astellingwerf](https://github.com/astellingwerf) reviews PRs
-- [@danports](https://github.com/danports)
+- [@danports](https://github.com/danports) Worked on the Flux manager, and other managers. Feel free to ping `@danports` for any Flux-related issue or PR.
 
 ## Renovate development
 

--- a/src/about-us.md
+++ b/src/about-us.md
@@ -23,7 +23,7 @@ Next up, we have these people who help maintain parts of Renovate:
 
 - [@HonkingGoose](https://github.com/HonkingGoose) master of the docs and community manager
 - [@zharinov](https://github.com/zharinov) focused on parsing, Gradle and Maven
-- [@secustor](https://github.com/secustor) worked on Terraform
+- [@secustor](https://github.com/secustor) worked on Terraform and Helm
 - [@fgreinacher](https://github.com/fgreinacher) worked on NuGet
 - [@Turbo87](https://github.com/Turbo87) has helped in multiple areas, especially Cargo
 

--- a/src/about-us.md
+++ b/src/about-us.md
@@ -2,7 +2,39 @@
 
 Renovate was created by [WhiteSource](https://www.whitesourcesoftware.com/) staff and they continue to work on Renovate.
 
-More than 500 outside contributors helped improve Renovate.
+More than 600 outside contributors helped improve Renovate.
+
+## Special thanks
+
+We want to highlight the work of some very awesome people.
+Thank you very much for your time and effort!
+
+### Maintainers
+
+Renovate is maintained by:
+
+- [@rarkins](https://github.com/rarkins)
+- [@viceice](https://github.com/viceice)
+- [@JamieMagee](https://github.com/JamieMagee)
+
+### Maintainers for features
+
+Next up, we have these people who help maintain parts of Renovate:
+
+- [@HonkingGoose](https://github.com/HonkingGoose) master of the docs and community manager
+- [@zharinov](https://github.com/zharinov) focused on parsing, Gradle and Maven
+- [@secustor](https://github.com/secustor) worked on Terraform
+- [@fgreinacher](https://github.com/fgreinacher) worked on NuGet
+- [@Turbo87](https://github.com/Turbo87) has helped in multiple areas, especially Cargo
+
+### Valuable contributions
+
+We want to highlight these valuable contributions, even if they are one-offs.
+Some feature made a lot of people happy, and efficient!
+
+- [@ikesyo](https://github.com/ikesyo) regularly helpful
+- [@astellingwerf](https://github.com/astellingwerf) reviews PRs
+- [@danports](https://github.com/danports)
 
 ## Renovate development
 


### PR DESCRIPTION
## Changes:

- Credit:
  - Maintainers 
  - Frequent contributors for smaller parts
  - Helpful contributions, even one-offs
- Bump amount of contributors to Renovate to `600`

## Context:

Closes https://github.com/renovatebot/renovate/issues/11187