### PR TITLE
docs: use new brand name in about us page

### DIFF
--- a/src/about-us.md
+++ b/src/about-us.md
@@ -1,6 +1,6 @@
 # About us
 
-Renovate was created by [WhiteSource](https://www.whitesourcesoftware.com/) staff and they continue to work on Renovate.
+Renovate was created by [Mend](https://www.mend.io/) staff and they continue to work on Renovate.
 
 More than 500 outside contributors helped improve Renovate.
 


### PR DESCRIPTION
## Changes:

- Replace `Whitesource` with `Mend` in about us page

## Context:

Let's fix this, until we merge https://github.com/renovatebot/renovate/pull/15661. 😉 