### PR TITLE
chore: enable collapsible admonition blocks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,7 +113,7 @@ markdown_extensions:
   # We're using this to get a button on the homepage that links to our GitHub app.
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists
   - attr_list
-  
+
   # The Details extension supercharges the Admonition extension, making the resulting call-outs collapsible, allowing them to be opened and closed by the user.
   # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.
   - pymdownx.details

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,10 @@ markdown_extensions:
   # We're using this to get a button on the homepage that links to our GitHub app.
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists
   - attr_list
+  
+  # The Details extension supercharges the Admonition extension, making the resulting call-outs collapsible, allowing them to be opened and closed by the user.
+  # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.
+  - pymdownx.details
 
 # Page Tree/Sidebar
 # https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation


### PR DESCRIPTION
## Changes:

- Enable collapsible admonition blocks by using the `pymdownx.details` [^docs] extension

## Context:

We're using `??? note` admonitions, which are "collapsible", in this PR: https://github.com/renovatebot/renovate/pull/15791. This will only work with the changes in this PR.

[^docs]: [Material for MkDocs documentation, Details](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/?h=details#details)
