### PR TITLE
ci: don't install and build twice

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -85,9 +85,10 @@ jobs:
         uses: cypress-io/github-action@31b3f686c1ee05fb7390cc106d1f09eb83919a3c # tag=v3.2.0
         with:
           spec: cypress/integration/sample.spec.ts
-          build: make
           start: mkdocs serve
           wait-on: 'http://127.0.0.1:8000/'
+          # we have already installed all dependencies above
+          install: false
         timeout-minutes: 3
 
       - name: Publish docs


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- currently the cypress action runs `make`, which isn't needed here, as we already done it in steps before
- also disabled to run `yarn install` again
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
