### PR TITLE
fix: Update link to docker image

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -37,7 +37,7 @@ Renovate is used by:
 You can run Renovate as:
 
 - an [Open Source npm package](https://www.npmjs.com/package/renovate)
-- a [pre-built Open Source image on Docker Hub](https://hub.docker.com/repository/docker/renovate/renovate)
+- a [pre-built Open Source image on Docker Hub](https://hub.docker.com/r/renovate/renovate)
 - a [free GitHub App](https://github.com/marketplace/renovate) that is hosted by [Mend](https://mend.io/)
 
 [Install our GitHub app now](https://github.com/marketplace/renovate){ .md-button .md-button--primary }


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR updates the link to the Dockerimage, it seems that, when not logged in, the current link just points to a login page.

- https://hub.docker.com/repository/docker/renovate/renovate:
   <img width="910" alt="image" src="https://user-images.githubusercontent.com/16856448/175027948-674bfadc-1a98-4838-bdbc-ed206fe1f5bc.png">
- The new link shows it correctly: 
   <img width="791" alt="image" src="https://user-images.githubusercontent.com/16856448/175028196-2b41f031-b57b-4375-96d3-35372d91a381.png">


<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
