### PR TITLE
fix: add custom `edit_url` mkdocs hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tmp
 /renovate-schema.json
 /dist
+__pycache__

--- a/mkdocs-hooks/custom-edit-url.py
+++ b/mkdocs-hooks/custom-edit-url.py
@@ -1,0 +1,6 @@
+# Reads the edit_url from the yaml page header and replaces the default one with it
+
+def on_page_context(context, page, config, **kwargs):
+    if 'edit_url' in page.meta:
+        page.edit_url = page.meta['edit_url']
+    return context

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,13 @@ markdown_extensions:
   # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.
   - pymdownx.details
 
+# Plugins
+plugins:
+  - search
+  - mkdocs-simple-hooks:
+      hooks:
+        on_page_context: 'mkdocs-hooks.custom-edit-url:on_page_context'
+
 # Page Tree/Sidebar
 # https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation
 nav:

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 markdown==3.3.7
 mkdocs==1.3.0
 mkdocs-material==8.3.6
+mkdocs-simple-hooks==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,10 +28,13 @@ mkdocs==1.3.0
     # via
     #   -r requirements.in
     #   mkdocs-material
+    #   mkdocs-simple-hooks
 mkdocs-material==8.3.6
     # via -r requirements.in
 mkdocs-material-extensions==1.0.3
     # via mkdocs-material
+mkdocs-simple-hooks==0.1.5
+    # via -r requirements.in
 packaging==21.3
     # via mkdocs
 pygments==2.12.0

--- a/src/index.md
+++ b/src/index.md
@@ -1,4 +1,6 @@
-## edit_url: https://github.com/renovatebot/renovatebot.github.io/edit/main/src/index.md
+---
+edit_url: https://github.com/renovatebot/renovatebot.github.io/edit/main/src/index.md
+---
 
 ![Renovate banner](https://app.renovatebot.com/images/whitesource_renovate_660_220.jpg)
 

--- a/src/index.md
+++ b/src/index.md
@@ -1,3 +1,5 @@
+## edit_url: https://github.com/renovatebot/renovatebot.github.io/edit/main/src/index.md
+
 ![Renovate banner](https://app.renovatebot.com/images/whitesource_renovate_660_220.jpg)
 
 # Renovate documentation


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR iterates on #139 and adds a hook, which allows to overwrite the `edit_url` via YAML font matter 

## Context:

This PR is similiar to #139 and makes it obsolete if accepted. //cc @HonkingGoose 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
