### PR TITLE
chore: show tooltip when hovering over abbreviation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,6 @@
 
 # Ignore the .venv directory
 .venv
+
+# Ignore the list of abbreviations, as Prettier messes up the syntax
+/includes/abbreviations.md

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,0 +1,27 @@
+<!-- Material for MkDocs shows a tooltip when you hover over any abbreviation in this list. -->
+<!-- https://squidfunk.github.io/mkdocs-material/reference/tooltips/#adding-a-glossary -->
+
+<!-- Please keep this list sorted from A-Z. -->
+
+*[AMI]: Amazon Machine Images
+*[AWS]: Amazon Web Services
+*[CD]: Continuous Deployment
+*[CI]: Continuous Integration
+*[CLI]: Command-Line Interface
+*[CVE]: Common Vulnerabilities and Exposures
+*[DCO]: Developer Certificate of Origin
+*[GCR]: Google Container Registry
+*[GPG]: GNU Privacy Guard
+*[IaC]: Infrastructure as Code
+*[IAM]: Identity and Access Management
+*[JRE]: Java Runtime Environment
+*[LTS]: Long Term Support
+*[OCI]: Open Container Initiative
+*[PAT]: Personal Access Token
+*[SDK]: Software Development Kit
+*[SemVer]: Semantic Versioning
+*[SSH]: Secure Shell
+*[SSL]: Secure Sockets Layer
+*[TLS]: Transport Layer Security
+*[URL]: Uniform Resource Locator
+*[UTC]: Coordinated Universal Time

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,16 @@ markdown_extensions:
   # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.
   - pymdownx.details
 
+  # The Abbreviations extension adds the ability to add a small tooltip to an element, by wrapping it with an abbr tag.
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#abbreviations
+  - abbr
+
+  # The Snippets extension adds the ability to embed content from arbitrary files into a document, including other documents or source files, by using a simple syntax.
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#snippets
+  - pymdownx.snippets:
+      auto_append:
+        - includes/abbreviations.md
+
 # Plugins
 plugins:
   - search


### PR DESCRIPTION
## Changes:

- Create list of common abbreviations
- Change `mkdocs.yml` config file so the tooltip feature can work [^tooltips]
- Edit `.prettierignore` file to prevent Prettier from messing up the formatting of the abbrevations list

## Context:

Replaces PR #194, that I messed up when merging `main` into my fork's branch.

[^tooltips]: https://squidfunk.github.io/mkdocs-material/reference/tooltips/