### PR TITLE
chore: get emojis working

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,6 @@
 
 # Ignore the list of abbreviations, as Prettier messes up the syntax
 /includes/abbreviations.md
+
+# Ignore the mkdocs.yml file, as Prettier moves some comments around
+mkdocs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,13 @@ markdown_extensions:
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists
   - attr_list
 
+  # We need this to get emojis working on Material for MkDocs.
+  # We also need the attr_list extension, which is already enabled in the lines above this comment.
+  # https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+
   # The Details extension supercharges the Admonition extension, making the resulting call-outs collapsible, allowing them to be opened and closed by the user.
   # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.
   - pymdownx.details


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add configuration for Material for MkDocs to get emojis working [^material-docs]
- Add `mkdocs.yml` to `.prettierignore` file to prevent messed up comments

## Context:

The swissquote article has `:smile` 😄 emoji at the end of the article. Right now this emoji doesn't render properly.

This PR changes things so that the `:smile:` shortcode is recognized, and rendered as 😄.

Closes #210.

### Prettier messes up formatting

I turned off Prettier for the `mkdocs.yml` file, as it moves my comments around.

#### Input

```yaml
  # The Attribute Lists extension allows us to add HTML attributes and CSS classes to almost every Markdown inline- and block-level element with a special syntax.
  # We're using this to get a button on the homepage that links to our GitHub app.
  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists
  - attr_list

  # We need this to get emojis working on Material for MkDocs.
  # We also need the attr_list extension, which is already enabled in the lines above this comment.
  # https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration
  - pymdownx.emoji:
      emoji_index: !!python/name:materialx.emoji.twemoji
      emoji_generator: !!python/name:materialx.emoji.to_svg

  # The Details extension supercharges the Admonition extension, making the resulting call-outs collapsible, allowing them to be opened and closed by the user.
  # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.
  - pymdownx.details
```

#### After Prettier run

```yaml
  # The Attribute Lists extension allows us to add HTML attributes and CSS classes to almost every Markdown inline- and block-level element with a special syntax.
  # We're using this to get a button on the homepage that links to our GitHub app.
  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists
  - attr_list

  # We need this to get emojis working on Material for MkDocs.
  # We also need the attr_list extension, which is already enabled in the lines above this comment.
  # https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration
  - pymdownx.emoji:
      emoji_index: !!python/name:materialx.emoji.twemoji
      emoji_generator: !!python/name:materialx.emoji.to_svg
        # The Details extension supercharges the Admonition extension, making the resulting call-outs collapsible, allowing them to be opened and closed by the user.
        # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.

  - pymdownx.details
```

[^material-docs]: https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/