### PR TITLE
chore: add announcement bar

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,3 +22,6 @@ mkdocs.yml
 
 # ignore generated pipfile lock
 /Pipfile.lock
+
+# Ignore overrides/main.html because Prettier messes up the formatting
+overrides/main.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,10 @@ edit_uri: edit/main/docs/usage/
 theme:
   name: 'material'
 
+  # Allow overriding the Material for MkDocs themes with a 'overrides' directory.
+  # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
+  custom_dir: overrides
+
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'
 
@@ -73,6 +77,10 @@ theme:
     # Use instant loading for internal links
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=instant#instant-loading
     - navigation.instant
+
+    # Mark the announcement bar as read.
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#mark-as-read
+    - announce.dismiss
 
 # CSS and JavaScript customizations
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,10 @@
+<!-- This file has the content for our announcement bar. -->
+<!-- Use target="_blank" when linking to a external site, so the link opens in a new tab. -->
+<!-- https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#announcement-bar -->
+<!-- https://squidfunk.github.io/mkdocs-material/customization/#overriding-blocks -->
+
+{% extends "base.html" %}
+
+{% block announce %}
+Read the release notes for our recent major release: <a href="https://github.com/renovatebot/renovate/releases/tag/32.0.0" target="_blank">32.0.0</a>.
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,5 +6,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-Read the release notes for our recent major release: <a href="https://github.com/renovatebot/renovate/releases/tag/32.0.0" target="_blank">32.0.0</a>.
+Read how Swissquote uses Renovate in the new <a href="https://docs.renovatebot.com/user-stories/swissquote/" target="_blank">Swissquote user story</a> on our site.
 {% endblock %}


### PR DESCRIPTION
## Changes:

- Add announcement bar with a link to the latest Renovate `major` version

## Context:

Closes #131.