### PR TITLE
docs(index): add button for tutorial

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -44,6 +44,5 @@ You can run Renovate as:
 - a [pre-built Open Source image on Docker Hub](https://hub.docker.com/r/renovate/renovate)
 - a [free GitHub App](https://github.com/marketplace/renovate) that is hosted by [Mend](https://www.mend.io/)
 
-Take your first steps with Renovate by checking out our [tutorial](https://github.com/renovatebot/tutorial).
-
 [Install our GitHub app now](https://github.com/marketplace/renovate){ .md-button .md-button--primary }
+[Check out our tutorial](https://github.com/renovatebot/tutorial){ .md-button }


### PR DESCRIPTION
## Changes:

- Replace text that talks about the tutorial with a secondary call to action button

## Context:

![second-call-to-action-button-for-tutorial](https://user-images.githubusercontent.com/34918129/185370500-40e1b88c-c8f9-4d3e-b4cb-35dc1d2efac9.png)