### PR TITLE
chore: change announcement bar text

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,5 +6,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-Read how Swissquote uses Renovate in the new <a href="https://docs.renovatebot.com/user-stories/swissquote/" target="_blank">Swissquote user story</a> on our site.
+We created a new section in our docs to show how individuals and companies use Renovate bot. The first article shows <a href="https://docs.renovatebot.com/user-stories/swissquote/" target="_blank">how Swissquote uses Renovate</a>.
 {% endblock %}


### PR DESCRIPTION
## Changes:

- Rewrite announcement bar text to explain:
  - That _we_ made a new user stories section, about how individuals and companies use Renovate
  - That the _first_ article is about how Swissquote uses Renovate

## Context:

Clearing up some confusion from readers about the new section. I hope the new text also shows that it's about _other_ companies that use Renovate bot, not that Swissquote suddenly _owns_ Renovate bot.