### PR TITLE
chore: enable anchor following

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,10 @@ theme:
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=integrate#integrated-table-of-contents
     - toc.integrate
 
+    # Automatically scroll the navigation sidebar, so the active anchor is always on screen.
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-following
+    - toc.follow
+
     # Use instant loading for internal links
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=instant#instant-loading
     - navigation.instant


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Enable the anchor following feature [^anchor-following-docs]

## Context:

The navigation sidebar now scrolls when you scroll through the content. Now you can always see the anchor link in the sidebar.

This feature will be handy to help users navigate some large pages of our docs, most notably the _Configuration Options_ page. 😉 

## Testing my work:

1. Open my branch in Gitpod, or your workstation
2. Run `make && make serve`
3. Go to the development preview browser window
4. In the navigation sidebar click on _Configuration_ -> _Repository_ to open the Configuration Options docs
5. Scroll through the page, check the sidebar moves with the page content

[^anchor-following-docs]: https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-following