### PR TITLE
ci: enable Prettier cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "prettier": "prettier --check --ignore-unknown \"**/*.*\"",
-    "prettier-fix": "prettier --write --ignore-unknown \"**/*.*\""
+    "prettier": "prettier --check --ignore-unknown --cache \"**/*.*\"",
+    "prettier-fix": "prettier --write --ignore-unknown --cache \"**/*.*\""
   },
   "devDependencies": {
     "@testing-library/cypress": "8.0.3",


### PR DESCRIPTION
## Changes:

- Enable Prettier's `--cache` option [^prettier-docs]

## Context:

This speeds up the `yarn prettier` and `yarn prettier-fix` commands when you run them the _second_ time. But the _first_ run of Prettier is slower, because it needs to build the cache.

I'll let you guys decide if the slowdown of the first run (like in GitHub Actions), is worth the speed-up on a second run.

It would be nice if we could get the Prettier cache in our GitHub Actions, so the actions often have a nearly up-to-date cache.

[^prettier-docs]: https://prettier.io/docs/en/cli.html#--cache