### PR TITLE
chore: disable announcement bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ theme:
 
   # Allow overriding the Material for MkDocs themes with a 'overrides' directory.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  custom_dir: overrides
+  # custom_dir: overrides // Commenting out this config option to disable our announcement bar. The overrides/main.html file has the code for the announcement bar.
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'


### PR DESCRIPTION
## Changes:

- Disable the announcement bar by commenting out the "link" to the `overrides/main.html` file that has the announcement bar content

## Context:

Commenting out things in the `overrides/main.html` file doesn't get rid of the announcement bar completely (you still see a "flash" of the old content when you refresh or land on the page.

So I'm doing a bit of hack-job here, and just comment out the "link" to the `overrides/main.html` file. This way we keep the code for the announcement bar.

## Alternative option:

I could also `git revert` the two commits that introduced the announcement bar, and the change to the announcement bar text. But that means having to `git revert` the first `git revert` yet again, after we figure out how to use the announcement bar later. 😄