### PR TITLE
build: use mkdocs-native hooks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,5 @@ name = "pypi"
 mkdocs = "==1.4.0"
 mkdocs-material = "==8.5.3"
 mkdocs-material-extensions = "==1.0.3"
-mkdocs-simple-hooks = "==0.1.5"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,6 @@ name = "pypi"
 mkdocs = "==1.4.0"
 mkdocs-material = "==8.5.3"
 mkdocs-material-extensions = "==1.0.3"
+mkdocs-simple-hooks = "==0.1.5"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dec6669d90d24c4a8ffc40ad8eb70601068a2f3f7e697218fb86ca38198871e1"
+            "sha256": "306189dfb8f8f5ac4e349f12bbe4409a1567ef828e25f48778ed1a1ae3fea2f4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,7 +27,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {
@@ -52,6 +52,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
+                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==4.12.0"
         },
         "jinja2": {
             "hashes": [
@@ -147,14 +155,6 @@
             "index": "pypi",
             "version": "==1.0.3"
         },
-        "mkdocs-simple-hooks": {
-            "hashes": [
-                "sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c",
-                "sha256:efeabdbb98b0850a909adee285f3404535117159d5cb3a34f541d6eaa644d50a"
-            ],
-            "index": "pypi",
-            "version": "==0.1.5"
-        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -192,7 +192,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -262,7 +262,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "urllib3": {
@@ -303,6 +303,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.1.9"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.8.1"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "306189dfb8f8f5ac4e349f12bbe4409a1567ef828e25f48778ed1a1ae3fea2f4"
+            "sha256": "dec6669d90d24c4a8ffc40ad8eb70601068a2f3f7e697218fb86ca38198871e1"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,7 +27,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
         "click": {
@@ -52,14 +52,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==4.12.0"
         },
         "jinja2": {
             "hashes": [
@@ -155,6 +147,14 @@
             "index": "pypi",
             "version": "==1.0.3"
         },
+        "mkdocs-simple-hooks": {
+            "hashes": [
+                "sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c",
+                "sha256:efeabdbb98b0850a909adee285f3404535117159d5cb3a34f541d6eaa644d50a"
+            ],
+            "index": "pypi",
+            "version": "==0.1.5"
+        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -192,7 +192,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -262,7 +262,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "urllib3": {
@@ -303,14 +303,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dec6669d90d24c4a8ffc40ad8eb70601068a2f3f7e697218fb86ca38198871e1"
+            "sha256": "306189dfb8f8f5ac4e349f12bbe4409a1567ef828e25f48778ed1a1ae3fea2f4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -27,7 +27,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {
@@ -52,6 +52,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
+                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==4.12.0"
         },
         "jinja2": {
             "hashes": [
@@ -146,14 +154,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.3"
-        },
-        "mkdocs-simple-hooks": {
-            "hashes": [
-                "sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c",
-                "sha256:efeabdbb98b0850a909adee285f3404535117159d5cb3a34f541d6eaa644d50a"
-            ],
-            "index": "pypi",
-            "version": "==0.1.5"
         },
         "packaging": {
             "hashes": [
@@ -303,6 +303,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.1.9"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.8.1"
         }
     },
     "develop": {}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,12 +8,6 @@ strict: true
 # https://www.mkdocs.org/user-guide/configuration/#remote_branch
 remote_branch: gh-pages
 
-# Hooks
-# https://www.mkdocs.org/user-guide/configuration/#hooks
-
-hooks:
-  - mkdocs-hooks/custom-edit-url.py
-
 # General site info
 
 # Metadata
@@ -161,6 +155,9 @@ markdown_extensions:
 # Plugins
 plugins:
   - search
+  - mkdocs-simple-hooks:
+      hooks:
+        on_page_context: 'mkdocs-hooks.custom-edit-url:on_page_context'
 
 # Page Tree/Sidebar
 # https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,12 @@ strict: true
 # https://www.mkdocs.org/user-guide/configuration/#remote_branch
 remote_branch: gh-pages
 
+# Hooks
+# https://www.mkdocs.org/user-guide/configuration/#hooks
+
+hooks:
+  - mkdocs-hooks/custom-edit-url.py
+
 # General site info
 
 # Metadata
@@ -155,9 +161,6 @@ markdown_extensions:
 # Plugins
 plugins:
   - search
-  - mkdocs-simple-hooks:
-      hooks:
-        on_page_context: 'mkdocs-hooks.custom-edit-url:on_page_context'
 
 # Page Tree/Sidebar
 # https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation


### PR DESCRIPTION
## Changes:

- Use MkDocs `1.4.0` [^changelog] native `hooks:` feature [^hooks]
- Run `pipenv uninstall mkdocs-simple-hooks` to drop the dependency

## Context:

Closes #229.

## Testing my work

1. Open my branch in Gitpod, or locally
1. Run `make && make serve`
1. Go to the Merge Confidence page in the preview
1. Click on the pencil icon (edit button)
1. Confirm you're taken to the correct source file on the correct repository

[^changelog]: https://github.com/mkdocs/mkdocs/releases/tag/1.4.0
[^hooks]: https://www.mkdocs.org/user-guide/configuration/#hooks