### PR TITLE
chore: add edit_url override to release notes page

### DIFF
--- a/src/release-notes-for-major-versions.md
+++ b/src/release-notes-for-major-versions.md
@@ -1,3 +1,7 @@
+---
+edit_url: https://github.com/renovatebot/renovatebot.github.io/edit/main/src/release-notes-for-major-versions.md
+---
+
 # Release notes for major versions of Renovate
 
 It can be hard to keep track of the changes between major versions of Renovate.


### PR DESCRIPTION
## Changes:

- Add `edit_url` yaml override

## Context:

The edit button (pencil icon) doesn't lead users to the correct location. We can override the default `edit_url` at the top of the page.

https://github.com/renovatebot/renovatebot.github.io/blob/650fb9126973f87298d3e2cd1288756a6697f800/mkdocs-hooks/custom-edit-url.py#L1-L6