### PR TITLE
chore: improve theme color contrast

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,15 +63,15 @@ theme:
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
-      primary: 'blue'
-      accent: 'blue'
+      primary: 'indigo'
+      accent: 'indigo'
     - media: '(prefers-color-scheme: dark)'
       scheme: slate
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
-      primary: 'cyan'
-      accent: 'cyan'
+      primary: 'teal'
+      accent: 'teal'
 
   features:
     # Back to top button


### PR DESCRIPTION
## Changes:

- Pick better colors to improve contrast:
  - Use a darker `indigo` for the light mode
  - Use a calmer `teal` color for the dark mode

## Context:

Material for MkDocs allows custom colors beyond just the "standard color" words, but to do that I would need to override the theme with custom CSS. I don't want to mess too much with the Material for MkDocs theme as that's prone to break. [^customization]

So instead I'm picking better colors from the existing "color words". With the new colors most elements get a WCAG AA contrast rating. [^rating] But some elements still lack good contrast. You can use the accessibility tools in Firefox or Chrome to check the contrast of each element on screen.

I think this is about the best that I can get it, without messing with the custom CSS. 🙈 

[^customization]: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#customization
[^rating]: https://webaim.org/articles/contrast/