### PR TITLE
chore: enable footnotes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,10 @@ markdown_extensions:
       auto_append:
         - includes/abbreviations.md
 
+  # The Footnotes extension adds the ability to add footnotes.
+  # https://squidfunk.github.io/mkdocs-material/reference/footnotes/
+  - footnotes
+
 # Plugins
 plugins:
   - search


### PR DESCRIPTION
## Changes:

- Enable Material for MkDocs built-in `footnotes` extension

## Context:

@JamieMagee opened a pull request with footnotes in it, over on the main Renovate repository:

- https://github.com/renovatebot/renovate/pull/18727/

To get footnotes in our docs, we need to enable the `footnotes` extension.

I'm marking this PR as a draft, I'm not sure footnotes are worth the trouble.

### Pros

- Footnotes don't disrupt the flow of the text as much as a full link

### Cons

- When writing docs, make sure to make a proper link for the footnote, or you can't even click the link, so always use the `[]()` Markdown link syntax
- The click target size for the footnote is too small, you really need to aim to click it
- I don't know how accessible footnotes are for screen-readers, maybe having the link in the flow of the text is easier than "jumping around" between numbered footnotes
  - We should probably use "named footnotes" so that a screen-reader has sensible text

## Footnotes syntax example

```markdown
The `nix`[^1] manager supports:

- `lockFileMaintenance` [^2] updates for `flake.lock`
- Extracts `nixpkgs` [^3] references

[^1]: [NixOS docs on GitHub](https://github.com/NixOS/nix)
[^2]: [Renovate docs for `lockfileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)
[^3]: [NixOS docs for `nixpkgs`](https://github.com/NixOS/nixpkgs)
```

## Preview

![preview-footnotes-in-docs-site](https://user-images.githubusercontent.com/34918129/200276787-387334d4-c3f5-4637-ac8b-d18299af6526.png)