### PR TITLE
chore: update security.txt

### DIFF
--- a/src/security.txt
+++ b/src/security.txt
@@ -1,3 +1,5 @@
 Contact: mailto:renovate-disclosure@mend.io
-Expires: 2022-12-31T23:59:00.000Z
+Expires: 2024-12-31T23:59:00.000Z
 Preferred-Languages: en
+Canonical: https://docs.renovatebot.com/security.txt
+Policy: https://github.com/renovatebot/renovatebot.github.io/blob/main/SECURITY.md

--- a/src/security.txt
+++ b/src/security.txt
@@ -1,5 +1,5 @@
 Contact: mailto:renovate-disclosure@mend.io
-Expires: 2024-12-31T23:59:00.000Z
+Expires: 2023-12-31T23:59:00.000Z
 Preferred-Languages: en
 Canonical: https://docs.renovatebot.com/security.txt
 Policy: https://github.com/renovatebot/renovatebot.github.io/blob/main/SECURITY.md


### PR DESCRIPTION
## Changes:

- Bump expiry date to 31th of December 2023

Optional changes:
  - Add `Canonical` field that links to our Renovate docs domain
  - Add link to our security policy (I'm linking to the one on the Renovate docs repository!)

## Context:

The `security.txt` expires in December of this year. Let's bump the dates now, so we don't forget later. 😄 

I think we should add the Canonical and Policy fields.

Read the docs:

- https://securitytxt.org/