### PR TITLE
chore: disable announcement bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  custom_dir: overrides
+  # custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'


### PR DESCRIPTION
## Changes:

- Disable the announcement bar

## Context:

It's been nearly a month since we released the two new major versions of Renovate. We can probably disable the announcement bar now.