### PR TITLE
chore: capitalize abbreviation, add fullstop

### DIFF
--- a/mkdocs-hooks/custom-edit-url.py
+++ b/mkdocs-hooks/custom-edit-url.py
@@ -1,4 +1,4 @@
-# Reads the edit_url from the yaml page header and replaces the default one with it
+# Reads the edit_url from the YAML page header and replaces the default one with it.
 
 def on_page_context(context, page, config, **kwargs):
     if 'edit_url' in page.meta:


### PR DESCRIPTION
## Changes:

- Capitalize abbreviation YAML
- End sentence with full stop

## Context:

Drive-by PR. 😄 