### PR TITLE
chore: enable announcement bar, explain brownout

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  # custom_dir: overrides
+  custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,16 +6,8 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<p>If you're using the GitHub-hosted app version of Renovate, <em>and</em> you invited the <code>renovate</code> npm user into your npm organization then keep reading.</p>
-
 <p>
-  We are phasing out using the <code>renovate</code> npm user for private packages.
-  We are deliberately skipping provisioning this npm token for 20 percent of the time (brownout).
-  This means that Renovate will autoclose some pull requests, which will then be re-opened the next time Renovate runs with the token.
-</p>
-
-<p>
-  If you're seeing this behavior, it means you need to set up your own service user token.
+  We are phasing out use of the `renovate` npm user, which affects about 10 early users of the Renovate App on github.com.
   Read <a href="https://github.com/renovatebot/renovate/discussions/20613" target="_blank">discussion 20613 on the Renovate repository</a> to learn more.
 </p>
 {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,5 +6,16 @@
 {% extends "base.html" %}
 
 {% block announce %}
-We released two new major versions of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
+<p>If you're using the GitHub-hosted app version of Renovate, <em>and</em> you invited the <code>renovate</code> npm user into your npm organization then keep reading this message.</p>
+
+<p>
+  We are phasing out using the <code>renovate</code> npm user for private packages.
+  We are deliberately skipping provisioning this npm token for 20 percent of the time (brownout).
+  This means that Renovate will autoclose some pull requests, which will then be re-opened the next time Renovate runs with the token.
+</p>
+
+<p>
+  If you're seeing this behavior, it means you need to set up your own service user token.
+  Read <a href="https://github.com/renovatebot/renovate/discussions/20613" target="_blank">discussion 20613 on the Renovate repository</a> to learn more.
+</p>
 {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,7 +6,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<p>If you're using the GitHub-hosted app version of Renovate, <em>and</em> you invited the <code>renovate</code> npm user into your npm organization then keep reading this message.</p>
+<p>If you're using the GitHub-hosted app version of Renovate, <em>and</em> you invited the <code>renovate</code> npm user into your npm organization then keep reading.</p>
 
 <p>
   We are phasing out using the <code>renovate</code> npm user for private packages.


### PR DESCRIPTION
## Changes:

- Enable the announcement bar in config again
- Write announcement bar text for brownout

## Context:

Related discussion: 

- https://github.com/renovatebot/renovate/discussions/20613

### Preview image:

<img width="1600" alt="preview-announcement-bar-brownout" src="https://user-images.githubusercontent.com/34918129/222100928-ad481d6a-4be2-40b6-b3e7-8f17439ba57b.png">