### PR TITLE
chore: add `ghcr.io` announcement

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,4 +9,7 @@
 <p>
   We released <code>v35</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
 </p>
+<p>
+  In addition to Docker Hub, we're now also publishing our images on `ghcr.io`. Go to <a href="https://github.com/renovatebot/renovate/pkgs/container/renovate" target="_blank">Renovate's packages page on GitHub</a> for more information.
+</p>
 {% endblock %}


### PR DESCRIPTION
## Changes:

- Add `ghcr.io` announcement

## Context:

We're now also publishing images via `ghcr.io`. We should tell our users. 

### Preview

![preview-announcement-bar](https://user-images.githubusercontent.com/34918129/225957857-07e1fc6c-e254-468a-ab68-837377bc6791.png)