### PR TITLE
chore: add vm abbreviation to glossary

### DIFF
--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -26,3 +26,4 @@
 *[TLS]: Transport Layer Security
 *[URL]: Uniform Resource Locator
 *[UTC]: Coordinated Universal Time
+*[VM]: Virtual Machine


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add `VM` abbreviation to glossary

## Context:

Add missing abbreviation to the glossary. This means that when you hover over the `VM` abbrevation, you see a small pop-up with the full term "Virtual Machine".

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
