### PR TITLE
chore: add AUR abbreviation to glossary

### DIFF
--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -4,6 +4,7 @@
 <!-- Please keep this list sorted from A-Z. -->
 
 *[AMI]: Amazon Machine Images
+*[AUR]: Arch User Repository
 *[AWS]: Amazon Web Services
 *[CD]: Continuous Deployment
 *[CI]: Continuous Integration


### PR DESCRIPTION
## Changes:

- Add `AUR` abbreviation to glossary

## Context:

Only merge this _after_ this PR:

- https://github.com/renovatebot/renovate/pull/21413