### PR TITLE
chore: disable announcement bar, remove GHCR text

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  custom_dir: overrides
+  # custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,7 +9,4 @@
 <p>
   We released <code>v35</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
 </p>
-<p>
-  In addition to Docker Hub, we're now also publishing our images on `ghcr.io`. Go to <a href="https://github.com/renovatebot/renovate/pkgs/container/renovate" target="_blank">Renovate's packages page on GitHub</a> for more information.
-</p>
 {% endblock %}


### PR DESCRIPTION
## Changes:

- Disable the announcement bar in the MkDocs config file by commenting out a line
- Remove the text about us publishing container images on GHCR

## Context:

We've shown the `v35` and the GHCR announcements for over a month. Most readers will have seen the new stuff by now. 😄 