### PR TITLE
chore: DO NOT MERGE mockup config option as hover text

### DIFF
--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -48,3 +48,17 @@
 *[onboardingPrTitle]: Change this value to override the default onboarding PR title.
 *[configMigration]: Enable this to get config migration PRs when needed.
 *[productLinks]: Links which are used in PRs, issues and comments.
+*[hostType]: hostType for a package rule. Can be a platform name or a datasource name.
+*[matchHost]: A domain name, host name or base URL to match against.
+*[timeout]: Timeout (in milliseconds) for queries to external endpoints.
+*[insecureRegistry]: Explicitly turn on insecure Docker registry access (HTTP).
+*[authType]: Authentication type for HTTP header. e.g. `"Bearer"` or `"Basic"`. Use `"Token-Only"` to use only the token without an authorization type.
+*[hostRules]: Host rules/configuration including credentials.
+*[hostType]: hostType for a package rule. Can be a platform name or a datasource name.
+*[matchHost]: A domain name, host name or base URL to match against.
+*[addLabels]: Labels to add to Pull Request.
+*[labels]: Labels to set in Pull Request.
+*[packageRules]: Rules for matching package names.
+*[matchPackagePatterns]: Package name patterns to match. Valid only within a `packageRules` object.
+*[matchDepTypes]: List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.
+*[additionalBranchPrefix]: Additional string value to be appended to `branchPrefix`.

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -62,3 +62,4 @@
 *[matchPackagePatterns]: Package name patterns to match. Valid only within a `packageRules` object.
 *[matchDepTypes]: List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.
 *[additionalBranchPrefix]: Additional string value to be appended to `branchPrefix`.
+*[regexManagers]: Custom managers using regex matching.

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -3,6 +3,8 @@
 
 <!-- Please keep this list sorted from A-Z. -->
 
+<!-- Put real abbreviations in this section. -->
+
 *[AMI]: Amazon Machine Images
 *[AUR]: Arch User Repository
 *[AWS]: Amazon Web Services
@@ -28,3 +30,21 @@
 *[URL]: Uniform Resource Locator
 *[UTC]: Coordinated Universal Time
 *[VM]: Virtual Machine
+
+<!-- Grab description string from config options typescript file, and copy/paste it into the right format here -->
+
+*[detectGlobalManagerConfig]: If `true`, Renovate tries to detect global manager configuration from the file system.
+*[detectHostRulesFromEnv]: If `true`, Renovate tries to detect host rules from environment variables.
+*[allowPostUpgradeCommandTemplating]: Set this to `true` to allow templating for post-upgrade commands.
+*[allowedPostUpgradeCommands]: A list of regular expressions that decide which post-upgrade tasks are allowed.
+*[postUpgradeTasks]: Post-upgrade tasks that are executed before a commit is made by Renovate.
+*[commands]: A list of post-upgrade commands that are executed before a commit is made by Renovate.
+*[fileFilters]: Files that match the glob pattern will be committed after running a post-upgrade task.
+*[executionMode]: Controls when the post upgrade tasks run: on every update, or once per upgrade branch.
+*[onboardingBranch]: Change this value to override the default onboarding branch name.
+*[onboardingCommitMessage]: Change this value to override the default onboarding commit message.
+*[onboardingConfigFileName]: Change this value to override the default onboarding config file name.
+*[onboardingNoDeps]: Onboard the repository even if no dependencies are found.
+*[onboardingPrTitle]: Change this value to override the default onboarding PR title.
+*[configMigration]: Enable this to get config migration PRs when needed.
+*[productLinks]: Links which are used in PRs, issues and comments.


### PR DESCRIPTION
## Changes:

- Grab a few `description`s from [the main Renovate repository `lib/config/options/index.ts` file](https://github.com/renovatebot/renovate/blob/main/lib/config/options/index.ts) to use as "abbrevations"

## Context:

I thought, can we put the `descriptions` for our config options into the abbreviations glossary file, to show the `description` as hover text. So I went ahead and mocked this up! 😄 

Here's a rough proof of concept. And it doesn't work like I want it to. 😞

### Broken/bad stuff

The hover-feature only works with _normal_ text. A "config option" that's on the abbreviations-list but in `monospace` will _not_ show a hover text. Usually when we use a config option name we `monospace` it in our docs.

Terms like _label_ can mean Renovate `label` config option, or just "label on an issue". This can confuse our readers.

### How to test

1. Open GitHub Codespace on this PR
2. Wait for Codespaces to finish setup (or make sure you run `make` first)
3. Run `make serve`
4. Open browser, and go to the site preview on the Codespaces server
5. Go to the config options page, and scroll around, and hover with the mouse over terms
6. Search for terms in the abbreviations list and hover over them

### Related discussions on Material for MkDocs repo

- https://github.com/squidfunk/mkdocs-material/discussions/4923#discussioncomment-4799734
- https://github.com/squidfunk/mkdocs-material/discussions/5204
- https://github.com/squidfunk/mkdocs-material/discussions/5139#discussioncomment-5206454