### PR TITLE
chore: release notes for v36

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  # custom_dir: overrides
+  custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -7,6 +7,6 @@
 
 {% block announce %}
 <p>
-  We released <code>v35</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
+  We released <code>v36</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
 </p>
 {% endblock %}

--- a/src/release-notes-for-major-versions.md
+++ b/src/release-notes-for-major-versions.md
@@ -37,7 +37,8 @@ You also don't have to scroll to the bottom of the page to find the latest relea
 
 ### Commentary
 
-If you're self-hosting Renovate, play particular attention to:
+If you're self-hosting Renovate, pay particular attention to:
+
 - Do you want to run the full, or slim versions of the image? We have switched the defaults (latest is now slim, not full)
 - Have you configured `dockerImagePrefix`? If so then you need to use `dockerSidecarImage` instead
 - If you're using `config:base` in your `onboardingConfig` then switch to `config:recommended`

--- a/src/release-notes-for-major-versions.md
+++ b/src/release-notes-for-major-versions.md
@@ -37,7 +37,11 @@ You also don't have to scroll to the bottom of the page to find the latest relea
 
 ### Commentary
 
-Insert maintainer commentary for `v36` here.
+If you're self-hosting Renovate, play particular attention to:
+- Do you want to run the full, or slim versions of the image? We have switched the defaults (latest is now slim, not full)
+- Have you configured `dockerImagePrefix`? If so then you need to use `dockerSidecarImage` instead
+- If you're using `config:base` in your `onboardingConfig` then switch to `config:recommended`
+- `gitAuthor` may change if you're on GitLab and have a different commit email for your bot account. If so then configure `gitIgnoredAuthors` with the old email
 
 ### Link to release notes
 

--- a/src/release-notes-for-major-versions.md
+++ b/src/release-notes-for-major-versions.md
@@ -11,6 +11,22 @@ The most recent versions are always at the top of the page.
 This is because recent versions may revert changes made in an older version.
 You also don't have to scroll to the bottom of the page to find the latest release notes.
 
+## Version 36
+
+### Breaking changes
+
+- List all the breaking changes for `v36`
+- Breaking change 2
+- Breaking change 3
+
+### Commentary
+
+Insert maintainer commentary for `v36` here.
+
+### Link to release notes
+
+[Release notes for `v36` on GitHub](https://github.com/renovatebot/renovate/releases/tag/36.0.0).
+
 ## Version 35
 
 ### Breaking changes

--- a/src/release-notes-for-major-versions.md
+++ b/src/release-notes-for-major-versions.md
@@ -15,9 +15,25 @@ You also don't have to scroll to the bottom of the page to find the latest relea
 
 ### Breaking changes
 
-- List all the breaking changes for `v36`
-- Breaking change 2
-- Breaking change 3
+- postUpgradeTasks.fileFilters is now optional and defaults to all files
+- `languages` are now called `categories` instead. Use `matchCategories` in `packageRules`
+- Node v19 is no longer supported
+- **datasource:** `semver-coerced` is now the default versioning
+- **presets:** Preset `config:base` is now called `config:recommended` (will be migrated automatically)
+- remove `BUILDPACK` env support
+- **package-rules:** `matchPackageNames` now matches both `depName` (existing) and `packageName` (new) and warns if only `depName` matches
+- **release-notes:** Release notes won't be fetched early for `commitBody` insertion unless explicitly configured with `fetchReleaseNotes=branch`
+- `dockerImagePrefix` is now replaced by `dockerSidecarImage`
+- `matchPaths` and `matchFiles` are now combined into `matchFileNames`, supporting exact match and glob-only. The "any string match" functionality of `matchPaths` is now removed
+- **presets:** v25 compatibility for language-based branch prefixes is removed
+- **npm:** Rollback PRs will no longer be enabled by default for npm (they are now disabled by default for all managers)
+- **post-upgrade-tasks:** dot files will now be included by default for all minimatch results
+- **platform/gitlab:** GitLab `gitAuthor` will change from the account's "email" to "commit_email" if they are different
+- **automerge:** Platform automerge will now be chosen by default whenever automerge is enabled
+- Post upgrade templating is now allowed by default, as long as the post upgrade task command is itself already allowed
+- Official Renovate Docker images now use the "slim" approach with `binarySource=install` by default. e.g. `renovate/renovate:latest` is the slim image, not full
+- The "full" image is now available via the tag `full`, e.g. `renovate/renovate:36-full`, and defaults to `binarySource=global` (no dynamic installs)
+- Third party tools in the full image have been updated to latest/LTS major version
 
 ### Commentary
 


### PR DESCRIPTION
## Changes:

- Update our Release notes for major versions document
- Enable the announcement bar, and point to `v36` release notes in it

## Context:

We released Renovate `v36`. 🥳 So we should update our own release notes and commentary. 😉 

## Todos:

- [x] Copy/paste breaking changes from official changelogs
- [x] Decide what else to highlight in the announcement bar:
  - [ ] `config:base` to `config:recommended`?
  - [ ] `config:best-practices`?
  - [ ] The `renovate/renovate` Docker image changes? https://github.com/renovatebot/docker-renovate/pull/1518
- [x] Insert proper maintainer commentary
- [ ] Test the announcement bar works in Codespaces: #294
- [x] Mark PR ready to go
- [x] Get final review from maintainers