### PR TITLE
ci: check devcontainer works

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,23 @@
+name: Devcontainer
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  devcontainer-test:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Build and run dev container task
+        uses: devcontainers/ci@57eaf0c9b518a76872bc429cdceefd65a912309b # v0.3.1900000329
+        with:
+          runCmd: make


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Copy/paste from our [main Renovate repository `.github/workflows/devcontainer.yml`](https://github.com/renovatebot/renovate/blob/5dce6bbee525e0dc44944eb01b5991dabf6cbdbb/.github/workflows/devcontainer.yml)
- Run Codespace container before merges to `main`.

## Context:

I'd like to run the GitHub Codespaces devcontainer before merging Renovate updates, or our own PRs. I'd like to prevent accidental breakage like in this issue:

- #294