### PR TITLE
docs: update index page

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -29,7 +29,7 @@ Renovate works on these platforms:
 - [Bitbucket Server](./modules/platform/bitbucket-server/)
 - [Azure DevOps](./modules/platform/azure/)
 - [AWS CodeCommit](./modules/platform/codecommit/)
-- [Gitea](./modules/platform/gitea/)
+- [Gitea and Forgejo](./modules/platform/gitea/)
 
 ## Who Uses Renovate?
 

--- a/src/index.md
+++ b/src/index.md
@@ -43,7 +43,8 @@ You can run Renovate as:
 
 - an [Open Source npm package](https://www.npmjs.com/package/renovate)
 - a [pre-built Open Source image on Docker Hub](https://hub.docker.com/r/renovate/renovate)
-- a [free GitHub App](https://github.com/marketplace/renovate) that is hosted by [Mend](https://www.mend.io/)
 
-[Install our GitHub app now](https://github.com/marketplace/renovate){ .md-button .md-button--primary }
+Or you can use [the Mend Renovate App](https://github.com/marketplace/renovate) which is hosted by [Mend](https://www.mend.io/).
+
+[Install the Mend Renovate app now](https://github.com/marketplace/renovate){ .md-button .md-button--primary }
 [Check out our tutorial](https://github.com/renovatebot/tutorial){ .md-button }

--- a/src/index.md
+++ b/src/index.md
@@ -46,5 +46,5 @@ You can run Renovate as:
 
 Or you can use [the Mend Renovate App](https://github.com/marketplace/renovate) which is hosted by [Mend](https://www.mend.io/).
 
-[Install the Mend Renovate app now](https://github.com/marketplace/renovate){ .md-button .md-button--primary }
+[Install the Mend Renovate app for GitHub](https://github.com/marketplace/renovate){ .md-button .md-button--primary }
 [Check out our tutorial](https://github.com/renovatebot/tutorial){ .md-button }


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add Forgejo to list of supported platforms
- Use `the Mend Renovate app` to refer to the GitHub-hosted app
- Split the Mend Renovate app from the three list items, into its own sentence
- Update call to action button text

## Context:

Related issue:

- https://github.com/renovatebot/renovate/issues/23333

Preview image for the improved index page:

![preview-bottom-index-page](https://github.com/renovatebot/renovatebot.github.io/assets/34918129/d579319a-464e-4726-938a-b29a9a2768de)


