### PR TITLE
chore: disable announcement bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  custom_dir: overrides
+  # custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Comment out the announcement bar configuration

## Context:

We released Renovate `36.0.0` on the 4th of July. It's been just over a month now. I expect most users will have seen the announcement by now. So we can disable it again.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
