### PR TITLE
chore: enable navigation pruning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,11 @@ theme:
       accent: 'teal'
 
   features:
+    # Navigation pruning (not compatible with navigation.expand)
+    # When pruning is enabled, only the visible navigation items are included in the rendered HTML, reducing the size of the built site by 33% or more.
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-pruning
+    - navigation.prune
+
     # Back to top button
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=back+to+top#back-to-top-button
     - navigation.top


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Enable new Material for MkDocs feature: navigation pruning [^1]

## Context:

> When pruning is enabled, only the visible navigation items are included in the rendered HTML, __reducing the size of the built site by 33% or more__. Add the following lines to `mkdocs.yml`:
> 
> ``` yaml
> theme:
>   features:
>     - navigation.prune
> ```
> 
> This feature flag is not compatible with `navigation.expand`, as navigation expansion requires the complete navigation structure.
> 
> This feature flag is especially useful for documentation sites with 100+ or even 1,000+ of pages, as the navigation makes up a significant fraction of the HTML.
> Navigation pruning will replace all expandable sections with links to the first page in that section (or the section index page).

[^1]: https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-pruning

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
