### PR TITLE
chore: have two sidebars again

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,10 +84,6 @@ theme:
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=back+to+top#back-to-top-button
     - navigation.top
 
-    # Integrate table of contents into left sidebar
-    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=integrate#integrated-table-of-contents
-    - toc.integrate
-
     # Automatically scroll the navigation sidebar, so the active anchor is always on screen.
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-following
     - toc.follow


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Removes `toc.integrate` so we have a left and right sidebar again

## Context:

Reverts this PR, with some extra changes to remove the comments:

- #128