### PR TITLE
chore: update publish-docs badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![publish-docs](https://github.com/renovatebot/renovatebot.github.io/workflows/publish-docs/badge.svg?branch=build)
+[![publish-docs](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml)
 
 # docs.renovatebot.com
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![publish-docs](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml)
+[![publish-docs](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml/badge.svg?branch=main)](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml)
 
 # docs.renovatebot.com
 


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Update `publish-docs` action status badge in our readme

## Context:

The badge we have now shows `no status`.

The [`publish-docs` status check](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml) also runs on other branches, but we probably only want to show the results of the `main` branch runs. So I'm limiting the badge to only show `main` branch results.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
