### PR TITLE
chore: release notes for Renovate v37

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  # custom_dir: overrides
+  custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -7,6 +7,6 @@
 
 {% block announce %}
 <p>
-  We released <code>v36</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
+  We released <code>v37</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/" target="_blank">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
 </p>
 {% endblock %}

--- a/src/release-notes-for-major-versions.md
+++ b/src/release-notes-for-major-versions.md
@@ -11,6 +11,20 @@ The most recent versions are always at the top of the page.
 This is because recent versions may revert changes made in an older version.
 You also don't have to scroll to the bottom of the page to find the latest release notes.
 
+## Version 37
+
+### Breaking changes
+
+- **maven:** use hunt strategy for registries
+- **npm:** drop explicit lerna support
+
+### Commentary
+
+We switched from "merge" strategy to "hunt" strategy to match with how Maven works.
+
+Lerna v7 does not need our explicit support anymore, so we dropped it.
+If you're on a version of Lerna before v7, you should prioritize upgrading to v7.
+
 ## Version 36
 
 ### Breaking changes


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Copy/paste breaking changes from [Renovate's `37.0.0` changelog](https://github.com/renovatebot/renovate/releases/tag/37.0.0)
- Draft developer commentary
- Update announcement bar text to `v37` and enable it again

## Context:

The hosted app is now using `v37`, so we should highlight the changelogs again in our docs.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
