### PR TITLE
chore: drop mkdocs-material-extensions dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 mkdocs = "==1.5.3"
 mkdocs-material = "==9.4.6"
-mkdocs-material-extensions = "==1.2"
 mkdocs-awesome-pages-plugin = "==2.9.2"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7c120466b5cee4ff51a301390bffee5eb974ec1f0f558a8673e389ec75fb2912"
+            "sha256": "fffa34f3ab70692355dcec43c5b5b38daf1b7c4ed437d31f8d5aebbbeecddb2c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -284,12 +284,11 @@
         },
         "mkdocs-material-extensions": {
             "hashes": [
-                "sha256:27e2d1ed2d031426a6e10d5ea06989d67e90bb02acd588bc5673106b5ee5eedf",
-                "sha256:c767bd6d6305f6420a50f0b541b0c9966d52068839af97029be14443849fb8a1"
+                "sha256:0297cc48ba68a9fdd1ef3780a3b41b534b0d0df1d1181a44676fda5f464eeadc",
+                "sha256:f0446091503acb110a7cab9349cbc90eeac51b58d1caa92a704a81ca1e24ddbd"
             ],
-            "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3"
         },
         "natsort": {
             "hashes": [
@@ -339,11 +338,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:77a82c621c58a83efc49a389159181d570e370fff9f810d3a4766a75fc678b66",
-                "sha256:94a0d8a03246712b64698af223848fd80aaf1ae4c4be29c8c61939b0467b5722"
+                "sha256:8cba67beb2a1318cdaf742d09dff7c0fc4cafcc290147ade0f8fb7b71522711a",
+                "sha256:f6c79941498a458852853872e379e7bab63888361ba20992fc8b4f8a9b61735e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.3"
+            "version": "==10.3.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -529,11 +528,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2",
-                "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
+                "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84",
+                "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.6"
+            "version": "==2.0.7"
         },
         "watchdog": {
             "hashes": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,8 +157,8 @@ markdown_extensions:
   # We also need the attr_list extension, which is already enabled in the lines above this comment.
   # https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
   # The Details extension supercharges the Admonition extension, making the resulting call-outs collapsible, allowing them to be opened and closed by the user.
   # We're using this to enable collapsible admonition blocks for the list of bug reports and feature requests per manager.


### PR DESCRIPTION
## Changes:

- Drop the `mkdocs-material-extensions` dependency because it's built-in to Material for MkDocs `9.4.0` [^1]
- Update Material for MkDocs config so it uses the built-in emoji stuff

## Context:

Supersedes PR #332.

[^1]: [Material for MkDocs `9.4.0` changelog, `emoji` highlighted](https://squidfunk.github.io/mkdocs-material/changelog/?h=emoji#9.4.0)
