### PR TITLE
chore: underline links

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -5,3 +5,6 @@
   margin-top: -5px;
   margin-right: -10px;
 }
+.md-typeset a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Changes:

- Underline links for accessibility

## Context:

We should underline links in the body text, because:

- Relying on color alone is bad for colorblind users, or those who prefer grayscale
- It clearly shows which part of the text is a link
- Underlining links is the default browser styling anyways
- GitHub defaults to underlining links [GitHub Blog, New Default: Underlined Links for Improved Accessibility](https://github.blog/changelog/2023-10-18-new-default-underlined-links-for-improved-accessibility/)

Material for MkDocs lacks a toggle for link underlining, so I'm overriding the default CSS.

## Related discussion

- https://github.com/squidfunk/mkdocs-material/discussions/6238