### PR TITLE
chore: try spike/search-preview-2 (do not merge)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 mkdocs = "==1.5.3"
-mkdocs-material = "==9.4.14"
 mkdocs-awesome-pages-plugin = "==2.9.2"
+mkdocs-material = {ref = "spike/search-preview-2", git = "git+https://github.com/squidfunk/mkdocs-material.git"}
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e2dfaa7aa0be6990e97fd12196079baad7dd699716491ce8844343c137cbb0d2"
+            "sha256": "4b088da4c10f9b560e3aacdb5daf15a9f967113a41f15807f51afccfddb68dcf"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -274,13 +274,9 @@
             "version": "==2.9.2"
         },
         "mkdocs-material": {
-            "hashes": [
-                "sha256:a511d3ff48fa8718b033e7e37d17abd9cc1de0fdf0244a625ca2ae2387e2416d",
-                "sha256:dbc78a4fea97b74319a6aa9a2f0be575a6028be6958f813ba367188f7b8428f6"
-            ],
-            "index": "pypi",
+            "git": "git+https://github.com/squidfunk/mkdocs-material.git",
             "markers": "python_version >= '3.8'",
-            "version": "==9.4.14"
+            "ref": "6af73667b36c2c1043252d3bc9f772a665295ae6"
         },
         "mkdocs-material-extensions": {
             "hashes": [


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Try [the `spike/search-preview-2` branch from upstream Material for MkDocs](https://github.com/squidfunk/mkdocs-material/pull/6372)

## Context:

The `spike/search-preview-*` branches _won't_ get merged upstream, it's just to gather feedback. So we _shouldn't_ merge this PR. I'm marking this PR as draft to prevent accidental merges into production.

I tried some searches on the spike 1 preview, and it seems the _same_ as our current search. I used the `pipenv install git+https://github.com/squidfunk/mkdocs-material.git@spike/search-preview-1` command to install the search preview, and then ran `make serve` to try the new search.

Searches with the `spike/search-preview-2` package are different. I don't know if it's better or worse yet.

Related issue:

- #337

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
