### PR TITLE
chore: improve Material for MkDocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,11 @@ repo_name: renovatebot/renovate
 repo_url: https://github.com/renovatebot/renovate
 edit_uri: edit/main/docs/usage/
 
+# Watch the includes directory that has the abbreviations.md file.
+# Now the preview will update automatically when the abbreviations file is changed.
+watch:
+  - includes
+
 # Theme settings
 theme:
   name: 'material'
@@ -67,6 +72,11 @@ theme:
   # https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/
 
   palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
     - media: '(prefers-color-scheme: light)'
       scheme: default
       toggle:
@@ -74,11 +84,12 @@ theme:
         name: Switch to dark mode
       primary: 'indigo'
       accent: 'indigo'
+
     - media: '(prefers-color-scheme: dark)'
       scheme: slate
       toggle:
         icon: material/weather-sunny
-        name: Switch to light mode
+        name: Switch to system preference
       primary: 'teal'
       accent: 'teal'
 


### PR DESCRIPTION
## Changes:

- Configure automatic light / dark mode [^1]
- Watch the `includes` directory, so the preview updates when you edit the `abbreviations.md` file

## Context:

Material for MkDocs reached another funding goal [^3], so we get access to new features. :partying_face: 

There's a privacy plugin [^2], but that only works with fully qualified URLs, and we autogenerate a lot of stuff with scripts. So I don't know if the Privacy Plugin would work properly.

[^1]: [Material for MkDocs, automatic light / dark mode](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode)
[^2]: [Material for MkDocs, privacy plugin](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#built-in-privacy-plugin)
[^3]: [Material for MkDocs, $14,000 Goat's Horn features](https://squidfunk.github.io/mkdocs-material/insiders/#14000-goats-horn)