### PR TITLE
chore(vercel): update for amazon linux 2023

### DIFF
--- a/bin/prepare-vercel.sh
+++ b/bin/prepare-vercel.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+yum install -y python3-pip
+
 # renovate: datasource=pypi depName=poetry
 POETRY_VERSION=1.8.2
 

--- a/bin/prepare-vercel.sh
+++ b/bin/prepare-vercel.sh
@@ -2,24 +2,9 @@
 
 set -e
 
-# PYTHON_VERSION=3.12.1
+# renovate: datasource=pypi depName=poetry
+POETRY_VERSION=1.8.2
 
-# yum install -y \
-#   openssl11 \
-#   sqlite \
-#   xz \
-#   ;
-
-# mkdir -p /usr/local/python
-
-# curl -sSLo /tmp/python.tar.xz "https://github.com/containerbase/python-prebuild/releases/download/${PYTHON_VERSION}/python-amzn-2-x86_64.tar.xz"
-
-# tar -xf /tmp/python.tar.xz -C /usr/local/python
-
-# ln -sf /usr/local/python/${PYTHON_VERSION}/bin/python /usr/local/bin/python
-# ln -sf /usr/local/python/${PYTHON_VERSION}/bin/pip /usr/local/bin/pip
-
-python -m pip install poetry
-# ln -sf /usr/local/python/${PYTHON_VERSION}/bin/poetry /usr/local/bin/poetry
+python3 -m pip install poetry==${POETRY_VERSION}
 
 poetry --version

--- a/bin/prepare-vercel.sh
+++ b/bin/prepare-vercel.sh
@@ -2,24 +2,24 @@
 
 set -e
 
-PYTHON_VERSION=3.12.1
+# PYTHON_VERSION=3.12.1
 
-yum install -y \
-  openssl11 \
-  sqlite \
-  xz \
-  ;
+# yum install -y \
+#   openssl11 \
+#   sqlite \
+#   xz \
+#   ;
 
-mkdir -p /usr/local/python
+# mkdir -p /usr/local/python
 
-curl -sSLo /tmp/python.tar.xz "https://github.com/containerbase/python-prebuild/releases/download/${PYTHON_VERSION}/python-amzn-2-x86_64.tar.xz"
+# curl -sSLo /tmp/python.tar.xz "https://github.com/containerbase/python-prebuild/releases/download/${PYTHON_VERSION}/python-amzn-2-x86_64.tar.xz"
 
-tar -xf /tmp/python.tar.xz -C /usr/local/python
+# tar -xf /tmp/python.tar.xz -C /usr/local/python
 
-ln -sf /usr/local/python/${PYTHON_VERSION}/bin/python /usr/local/bin/python
-ln -sf /usr/local/python/${PYTHON_VERSION}/bin/pip /usr/local/bin/pip
+# ln -sf /usr/local/python/${PYTHON_VERSION}/bin/python /usr/local/bin/python
+# ln -sf /usr/local/python/${PYTHON_VERSION}/bin/pip /usr/local/bin/pip
 
 python -m pip install poetry
-ln -sf /usr/local/python/${PYTHON_VERSION}/bin/poetry /usr/local/bin/poetry
+# ln -sf /usr/local/python/${PYTHON_VERSION}/bin/poetry /usr/local/bin/poetry
 
 poetry --version


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Vercel now uses amazon linux 2023 which comes with python 3.9 and openssl v3 🎉 
So i simplified the install steps.

They also support python 3.11, so we can probably rais our requirements to that version too.
<!-- Describe what behavior is changed by this PR. -->

## Context:
- https://renovatebot-docs-30k7k0ode-viceice.vercel.app/
- https://renovatebot-docs-git-chore-amz-lnx-2023-viceice.vercel.app/
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
