### PR TITLE
docs: drop obsolete extra js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ __pycache__
 /.vscode/*
 /yarn.lock
 .parcel-cache/
+/.cache/
 
 !.vscode/settings.json

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,8 +133,8 @@ theme:
 extra_css:
   - 'assets/css/style.css'
 
-extra_javascript:
-  - 'assets/js/fx.js'
+#extra_javascript:
+#  - 'assets/js/fx.js'
 
 # Extensions
 markdown_extensions:

--- a/src/assets/js/fx.js
+++ b/src/assets/js/fx.js
@@ -1,3 +1,0 @@
-document.title += ' | Renovate Docs';
-// TODO: Why do we need this?
-document.getElementsByClassName('md-header__button md-logo')[0].href = '/';


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Those are no longer needed:
- page title: mkdocs already adds `- Renovate docs` suffix
- logo link: i checked that all it works on all pages already without changing.
<!-- Describe what behavior is changed by this PR. -->

## Context:
- https://github.com/renovatebot/renovate/issues/23772
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
