### PR TITLE
docs: optimize logo style

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,9 +1,9 @@
+.md-header .md-header__button.md-logo {
+  padding: 0;
+}
 .md-header .md-header__button.md-logo img,
 .md-header .md-header__button.md-logo svg {
-  height: 35px;
-  width: 35px;
-  margin-top: -5px;
-  margin-right: -10px;
+  height: 1.5rem;
 }
 .md-typeset a {
   text-decoration: underline;


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
- use rem unit (logo is now 36px instead of 35, but better scalable)
- remove padding from outer anchor for better alignment (was a little shifted to top
- remove right margin to align with drawer on small page sizes.
<!-- Describe what behavior is changed by this PR. -->

## Context:
- https://github.com/renovatebot/renovate/issues/23772
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
