### PR TITLE
ci: use different lock schedule

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,7 +3,7 @@ name: lock-threads
 on:
   # run daily
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 1 * * *'
 
   # allow manual trigger
   workflow_dispatch:


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Automatic token has rate limit, so let's try a diffent schedule than the main repo.
<!-- Describe what behavior is changed by this PR. -->

## Context:
- https://github.com/dessant/lock-threads/issues/48#issuecomment-2069165802
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
