### PR TITLE
chore: enable announcement bar for v38

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  # custom_dir: overrides
+  custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,6 +6,6 @@
 
 {% block announce %}
 <p>
-  We released <code>v37</code> of Renovate. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/">Release notes for major versions of Renovate</a> section of the docs to learn what's changed.
+  We released Renovate <code>v38</code>. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/">Release notes for major versions of Renovate</a> to learn what's changed.
 </p>
 {% endblock %}


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Rewrite announcement bar text
- Update to mention `v38`
- Uncomment the `custom_dir: overrides` part in the `mkdocs.yml` config file, to enable the announcement bar

## Context:

We released `v38` of Renovate OSS.

I think Mend is rolling out `v38` to hosted app users now too. Or at least the roll out was planned for Sunday 4th of August.

Related things:

- https://github.com/renovatebot/renovate/discussions/30417
- https://github.com/renovatebot/renovate/pull/30384

In any case, the docs should highlight the release notes. 😄 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
