### PR TITLE
chore: allow non-strict build

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,4 +8,4 @@ if [[ "${CODESPACES}" == true ]]; then
 fi
 
 git submodule update --init
-COREPACK_ENABLE_DOWNLOAD_PROMPT=0 make
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0 make STRICT=false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image:
   context: .gitpod
 tasks:
   - init: >
-      COREPACK_ENABLE_DOWNLOAD_PROMPT=0 make
+      COREPACK_ENABLE_DOWNLOAD_PROMPT=0 make STRICT=false
     command: make serve
 
 ports:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 default: install build
 
+STRICT?=true
+
+ifeq ($(STRICT),true)
+  build_args=--strict
+endif
+
 install:
 	pnpm install --frozen-lockfile
 	poetry install --no-root
@@ -16,7 +22,7 @@ get-docs:
 	bash bin/get-docs.sh
 
 build-docs:
-	poetry run mkdocs build
+	poetry run mkdocs build $(build_args)
 
 prepare: get-docs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 
 # Halt processing when a warning is raised when building the docs.
 # https://www.mkdocs.org/user-guide/configuration/#strict
-strict: true
+strict: false
 
 # Use MkDocs maintainer's recommended strictness settings for link validation.
 # https://www.mkdocs.org/user-guide/configuration/#validation


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Allow non-strict build via `make build-docs STRICT=false` and disable strict on gitpod and devcontainer startup.
<!-- Describe what behavior is changed by this PR. -->

## Context:
- Closes #463
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovatebot.github.io/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
