### PR TITLE
chore: deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,7 @@
-[![publish-docs](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml/badge.svg?branch=main)](https://github.com/renovatebot/renovatebot.github.io/actions/workflows/publish-docs.yml)
-
-# docs.renovatebot.com
-
-This repository is used to build Renovate's docs site (https://docs.renovatebot.com).
-
-The content itself is pulled from https://github.com/renovatebot/renovate, so you should raise PRs to that repository if you need to update the content that's displayed.
-
-The website is built and hosted by GitHub Pages.
-
-To build locally, run `make` and then `make serve`.
-
-## Contributing
-
-If you would like to contribute to this repository or get a local copy running for some other reason, please see the instructions in [.github/contributing.md](.github/contributing.md).
+> [!WARNING]
+> This repository is now archived, as it is no longer used.
+>
+> The docs build now happens entirely from [Renovate's own repository](https://github.com/renovatebot/renovate).
 
 ## Security / Disclosure
 


### PR DESCRIPTION
As we're now moving all docs builds into the main repo, per
renovatebot/renovate#39878.
